### PR TITLE
Raspberry pi fixes and other small improvements

### DIFF
--- a/UI24RBridgeTest/Program.cs
+++ b/UI24RBridgeTest/Program.cs
@@ -3,6 +3,7 @@ using Spectre.Console;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UI24RController;
 using UI24RController.MIDIController;
 
@@ -26,7 +27,7 @@ namespace UI24RBridgeTest
             var controllersSetting = new List<UI24RController.ControllerSettings>();
             configuration.GetSection("MidiControllers").Bind(controllersSetting);
 
-            
+
             var address = configuration["UI24R-Url"];
             var midiInputDevice = configuration["MIDI-Input-Name"];
             var midiOutputDevice = configuration["MIDI-Output-Name"];
@@ -55,7 +56,7 @@ namespace UI24RBridgeTest
             {
                 controllerSecond = MIDIControllerFactory.GetMidiController(protocol);
             }
-            
+
             if (args.Length > 0)
                 WriteMIDIDeviceNames(controller);
             else
@@ -156,7 +157,7 @@ namespace UI24RBridgeTest
                 Console.WriteLine("Start bridge...");
 
                 BridgeSettings settings = new BridgeSettings(address, messageWriter);
-                
+
                 if (syncID != null)
                 {
                     settings.SyncID = syncID;
@@ -251,9 +252,26 @@ namespace UI24RBridgeTest
                             }
                         }
                     }
-                    
+
                 }
             }
+        }
+        private static string PromptDeviceChoice(string promptText, IEnumerable<string> deviceNames)
+        {
+            var nameList = deviceNames.ToList();
+
+            AnsiConsole.WriteLine(promptText);
+            for (int i = 0; i < nameList.Count; i++)
+                AnsiConsole.MarkupLine($"  [blue][[{i + 1}]][/]: {nameList[i]}");
+
+            int chosen = AnsiConsole.Prompt(
+                new TextPrompt<int>("Enter number:")
+                    .DefaultValue(1)
+                    .Validate(n => n >= 1 && n <= nameList.Count
+                        ? ValidationResult.Success()
+                        : ValidationResult.Error($"Please enter a number between 1 and {nameList.Count}")));
+
+            return nameList[chosen - 1];
         }
 
         private static void CreateAppsettings(string fileName)
@@ -261,17 +279,15 @@ namespace UI24RBridgeTest
             var controller = MIDIControllerFactory.GetMidiController("MC");
             var inputDevicenames = controller.GetInputDeviceNames();
             var outputDevicenames = controller.GetOutputDeviceNames();
-            
+
             AnsiConsole.WriteLine("appsettings.json is not found.");
             AnsiConsole.WriteLine("Creating of the configuration file is starting.");
             var address = AnsiConsole.Ask<string>(@"Please write the mixer address (eg: ws:\\192.168.3.12): "); //"UI24R-Url"
-            var midiInputDevice = AnsiConsole.Prompt(
-                new TextPrompt<string>("Choose primary input device. (It is case sensitive.)")
-                .AddChoices(inputDevicenames));   //configuration["MIDI-Input-Name"];
+            var midiInputDevice = PromptDeviceChoice(
+                "Choose primary input device:", inputDevicenames); //configuration["MIDI-Input-Name"];
 
-            var midiOutputDevice = AnsiConsole.Prompt(
-                new TextPrompt<string>("Choose primary output device. (It is case sensitive.)")
-                .AddChoices(outputDevicenames));   //configuration["MIDI-Output-Name"];
+            var midiOutputDevice = PromptDeviceChoice(
+                "Choose primary output device:", outputDevicenames); //configuration["MIDI-Output-Name"];
 
             //var primaryIsExtender = configuration["PrimaryIsExtender"] == "true";
             string primaryIsExtender = "false";
@@ -290,7 +306,7 @@ namespace UI24RBridgeTest
                 new TextPrompt<string>("Primary controller offset (show 1-8ch: 0 9-16ch: 1")
                 .AddChoices(["0", "1"])
                 .DefaultValue("0"));
-           
+
             var isAddSecondaryDevice = AnsiConsole.Prompt(
                 new TextPrompt<bool>("Do you want to add secondary device?")
                     .AddChoice(true)
@@ -304,17 +320,15 @@ namespace UI24RBridgeTest
             string secondaryIsExtender = "false";
             string secondaryChannelStart = "1";
             //var secondaryMidiInputDevice = configuration["MIDI-Input-Name-Second"];
-            //var secondaryMidiOutputDevice = configuration["MIDI-Output-Name-Second"]; 
+            //var secondaryMidiOutputDevice = configuration["MIDI-Output-Name-Second"];
             //var secondaryIsExtender = configuration["SecondaryIsExtender"] == "true";
             if (isAddSecondaryDevice)
             {
-                secondaryMidiInputDevice = AnsiConsole.Prompt(
-                new TextPrompt<string>("Choose secondary input device. (It is case sensitive.)")
-                .AddChoices(inputDevicenames));   //configuration["MIDI-Input-Name"];
+                secondaryMidiInputDevice = PromptDeviceChoice(
+                    "Choose secondary input device:", inputDevicenames); //configuration["MIDI-Input-Name"];
 
-                secondaryMidiOutputDevice = AnsiConsole.Prompt(
-                    new TextPrompt<string>("Choose secondary output device. (It is case sensitive.)")
-                    .AddChoices(outputDevicenames));   //configuration["MIDI-Output-Name"];
+                secondaryMidiOutputDevice = PromptDeviceChoice(
+                    "Choose secondary output device:", outputDevicenames); //configuration["MIDI-Output-Name"];
 
                 if (AnsiConsole.Prompt(
                     new TextPrompt<bool>("Is secondary device an extender?")
@@ -370,7 +384,7 @@ namespace UI24RBridgeTest
 ";
 
             File.WriteAllText(fileName, settingsContent);
-            
+
 
         }
 

--- a/UI24RBridgeTest/UI24RBridgeTest.csproj
+++ b/UI24RBridgeTest/UI24RBridgeTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64</RuntimeIdentifiers>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>

--- a/UI24RController/MIDIController/BehringerUniversalMIDI.cs
+++ b/UI24RController/MIDIController/BehringerUniversalMIDI.cs
@@ -86,13 +86,13 @@ namespace UI24RController.MIDIController
             }
         }
 
-        public bool ConnectInputDevice(string deviceName)
+        public async Task<bool> ConnectInputDevice(string deviceName)
         {
             var access = MidiAccessManager.Default;
             var deviceNumber = access.Inputs.Where(i => i.Name == deviceName).FirstOrDefault();
             if (deviceNumber != null)
             {
-                _input = access.OpenInputAsync(deviceNumber.Id).Result;
+                _input = await access.OpenInputAsync(deviceNumber.Id);
                 _input.MessageReceived += (obj, e) =>
                 {
                     if (e.Data.Length>2)
@@ -104,7 +104,7 @@ namespace UI24RController.MIDIController
                 return true;
             }
             else
-                return false;            
+                return false;
         }
 
         private void ProcessMidiMessage(MidiReceivedEventArgs e)
@@ -122,13 +122,13 @@ namespace UI24RController.MIDIController
             }
         }
 
-        public bool ConnectOutputDevice(string deviceName)
+        public async Task<bool> ConnectOutputDevice(string deviceName)
         {
             var access = MidiAccessManager.Default;
             var deviceNumber = access.Outputs.Where(i => i.Name == deviceName).FirstOrDefault();
             if (deviceNumber != null)
             {
-                _output = access.OpenOutputAsync(deviceNumber.Id).Result;
+                _output = await access.OpenOutputAsync(deviceNumber.Id);
                 return true;
             }
             return false;
@@ -207,7 +207,7 @@ namespace UI24RController.MIDIController
             throw new NotImplementedException();
         }
 
-        public bool ReConnectDevice()
+        public async Task<bool> ReConnectDevice()
         {
             throw new NotImplementedException();
         }

--- a/UI24RController/MIDIController/IMIDIController.cs
+++ b/UI24RController/MIDIController/IMIDIController.cs
@@ -2,16 +2,17 @@
 using System.Collections.Generic;
 using UI24RController;
 using UI24RController.MIDIController;
+using System.Threading.Tasks;
 
 public interface IMIDIController
 {
     #region Connection
     string[] GetInputDeviceNames();
     string[] GetOutputDeviceNames();
-    bool ConnectInputDevice(string deviceName);
-    bool ConnectOutputDevice(string deviceName);
+    Task<bool> ConnectInputDevice(string deviceName);
+    Task<bool> ConnectOutputDevice(string deviceName);
 
-    bool ReConnectDevice();
+    Task<bool> ReConnectDevice();
 
     bool IsConnectionErrorOccured { get; }
     bool IsConnected { get; }

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -37,7 +37,7 @@ namespace UI24RController.MIDIController
         /// Store every fader setted value of the faders, key is the channel number (z in the message)
         /// </summary>
         protected ConcurrentDictionary<byte, FaderState> faderValues = new ConcurrentDictionary<byte, FaderState>();
-            
+
         IMidiInput _input = null;
         protected string _inputDeviceNumber;
         protected string _inputDeviceName;
@@ -420,10 +420,10 @@ namespace UI24RController.MIDIController
                 _output.Dispose();
                 _output = null;
             }
-           
+
         }
 
-        public  bool ConnectInputDevice(string deviceName)
+        public async Task<bool> ConnectInputDevice(string deviceName)
         {
             try
             {
@@ -432,8 +432,8 @@ namespace UI24RController.MIDIController
                 var deviceNumber = access.Inputs.Where(i => i.Name.ToUpper() == deviceName.ToUpper()).FirstOrDefault();
                 if (deviceNumber != null)
                 {
-                    
-                    var input = access.OpenInputAsync(deviceNumber.Id).Result;
+                    var input = await access.OpenInputAsync(deviceNumber.Id);
+
                     _input = input;
                     _inputDeviceNumber = deviceNumber.Id;
                     _input.MessageReceived += (obj, e) =>
@@ -458,7 +458,7 @@ namespace UI24RController.MIDIController
             }
             return false;
         }
-        public bool ConnectOutputDevice(string deviceName)
+        public async Task<bool> ConnectOutputDevice(string deviceName)
         {
             try
             {
@@ -467,7 +467,7 @@ namespace UI24RController.MIDIController
                 var deviceNumber = access.Outputs.Where(i => i.Name.ToUpper() == deviceName.ToUpper()).FirstOrDefault();
                 if (deviceNumber != null)
                 {
-                    var output = access.OpenOutputAsync(deviceNumber.Id).Result;
+                    var output = await access.OpenOutputAsync(deviceNumber.Id);
                     _outputDeviceNumber = deviceNumber.Id;
                     _output = output;
                     _isConnected = true;
@@ -503,10 +503,11 @@ namespace UI24RController.MIDIController
                 _pingThread.Start();
 
         }
-        public bool ReConnectDevice()
+        public async Task<bool> ReConnectDevice()
         {
-           return ConnectInputDevice(_inputDeviceName) &&
-            ConnectOutputDevice(_outputDeviceName);
+            var inputOk  = await ConnectInputDevice(_inputDeviceName);
+            var outputOk = await ConnectOutputDevice(_outputDeviceName);
+            return inputOk && outputOk;
         }
 
         public string[] GetInputDeviceNames()
@@ -530,7 +531,7 @@ namespace UI24RController.MIDIController
 
                 }
             }
-            catch 
+            catch
             {
                 OnConnectionErrorEvent();
             }
@@ -539,7 +540,7 @@ namespace UI24RController.MIDIController
         {
             var message = e.Data;
 
-            if (message[0] == 0x90) //button pressed, released, fader released 
+            if (message[0] == 0x90) //button pressed, released, fader released
             {
                 if (message.MIDIEqual(0x90, 0x00, 0x00, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //release fader (0x90 [0x68-0x70] 0x00)
                 {
@@ -794,7 +795,7 @@ namespace UI24RController.MIDIController
                 int lower = message[1]; // lower 7 bit
 
                 var faderValue = (upper + lower) / 16383.0;
-                
+
                 faderValues[channelNumber].Value = faderValue;
                 OnFaderEvent(channelNumber, faderValue);
                 if (!faderValues[channelNumber].IsTouched)

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -4,7 +4,6 @@ using System.Text;
 using Commons.Music.Midi;
 using System.Linq;
 using System.Threading.Tasks;
-using Commons.Music.Midi.RtMidi;
 using System.Threading;
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;

--- a/UI24RController/MIDIController/MackieHUI.cs
+++ b/UI24RController/MIDIController/MackieHUI.cs
@@ -14,7 +14,7 @@ namespace UI24RController.MIDIController
         /// Store every fader setted value of the faders, key is the channel number (z in the message)
         /// </summary>
         protected Dictionary<byte, double> faderValues = new Dictionary<byte, double>();
-            
+
         IMidiInput _input = null;
         IMidiOutput _output = null;
 
@@ -94,13 +94,13 @@ namespace UI24RController.MIDIController
             }
         }
 
-        public  bool ConnectInputDevice(string deviceName)
+        public async Task<bool> ConnectInputDevice(string deviceName)
         {
             var access = MidiAccessManager.Default;
             var deviceNumber = access.Inputs.Where(i => i.Name == deviceName).FirstOrDefault();
             if (deviceNumber != null)
             {
-                _input = access.OpenInputAsync(deviceNumber.Id).Result;
+                _input = await access.OpenInputAsync(deviceNumber.Id);
                 _input.MessageReceived += (obj, e) =>
                 {
                     if (e.Data.Length>2)
@@ -113,7 +113,7 @@ namespace UI24RController.MIDIController
                 return true;
             }
             else
-                return false;            
+                return false;
         }
 
         private void ProcessMidiMessage()
@@ -127,13 +127,13 @@ namespace UI24RController.MIDIController
                 if (firstMessage.MIDIEqual(0x90, 0x00, 0x7f)) //ping answer -> do nothing
                 {
                 }
-                else if(firstMessage.MIDIEqual(0xb0, 0x0f)&& (firstMessage[2] < 8)) //first message of:  release fader 
+                else if(firstMessage.MIDIEqual(0xb0, 0x0f)&& (firstMessage[2] < 8)) //first message of:  release fader
                 {
                     var channelNumber = firstMessage[2];
                     var secondMessage = _messageQueue.Dequeue();
                     if (secondMessage.MIDIEqual(0xb0, 0x2f, 0x00)) //release fader
                     {
-                        //TODO: Send back the last fader value to the controller 
+                        //TODO: Send back the last fader value to the controller
                         if (faderValues.ContainsKey(channelNumber))
                         {
                             SetFader(channelNumber, faderValues[channelNumber]);
@@ -154,7 +154,7 @@ namespace UI24RController.MIDIController
                         faderValues.AddOrSet(channelNumber, faderValue);
                         OnFaderEvent(channelNumber, faderValue);
                     }
-                }   
+                }
                 else if (firstMessage.MIDIEqual(0xb0, 0x0f, 0x0a)) //preset up, preset down
                 {
                     var secondMessage = _messageQueue.Dequeue();
@@ -171,13 +171,13 @@ namespace UI24RController.MIDIController
             }
         }
 
-        public  bool ConnectOutputDevice(string deviceName)
+        public async Task<bool> ConnectOutputDevice(string deviceName)
         {
             var access = MidiAccessManager.Default;
             var deviceNumber = access.Outputs.Where(i => i.Name == deviceName).FirstOrDefault();
             if (deviceNumber != null)
             {
-                _output = access.OpenOutputAsync(deviceNumber.Id).Result;
+                _output = await access.OpenOutputAsync(deviceNumber.Id);
                 return true;
             }
             return false;
@@ -201,11 +201,11 @@ namespace UI24RController.MIDIController
         {
             if (_output != null && channelNumber<8)
             {
-                //'touch fader': b0 0f 0z 
+                //'touch fader': b0 0f 0z
                 //               b0 2f 40
-                //'release fader': b0 0f 0z 
-                //                 b0 2f 00 
-                //'move fader': b0 0z hi 
+                //'release fader': b0 0f 0z
+                //                 b0 2f 00
+                //'move fader': b0 0z hi
                 //              b0 2z lo
                 //where z is the channel number 1-8
                 //hi is between 0x00-0x7f
@@ -220,7 +220,7 @@ namespace UI24RController.MIDIController
                 //touch fader on channel
                 //_output.Send(new byte[] {data0, 0x0f, z }, 0, 3, 0);
                 //_output.Send(new byte[] { data0, 0x2f, 0x40 }, 0, 3, 0);
-                //move fader 
+                //move fader
                 _output.Send(new byte[] { data0, (byte)(0x00 + z), upper }, 0, 3, 0);
                 _output.Send(new byte[] { data0, (byte)(0x20 + z), lower }, 0, 3, 0);
                 faderValues.AddOrSet(z, faderValue);
@@ -278,7 +278,7 @@ namespace UI24RController.MIDIController
             throw new NotImplementedException();
         }
 
-        public bool ReConnectDevice()
+        public async Task<bool> ReConnectDevice()
         {
             throw new NotImplementedException();
         }

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -34,10 +34,10 @@ namespace UI24RController
         protected SelectedLayoutEnum _selectedLayout = SelectedLayoutEnum.Channels;
 
         protected bool _isReconnecting = false;
- 
+
         /// <summary>
         /// Represent the UI24R mixer state
-        /// TODO: need to move every global variable that store any mixer specific state to the Mixer class (viewGroups, selectedChannel etc.) 
+        /// TODO: need to move every global variable that store any mixer specific state to the Mixer class (viewGroups, selectedChannel etc.)
         /// </summary>
         protected Mixer _mixer = new Mixer();
 
@@ -107,7 +107,7 @@ namespace UI24RController
 
             }
             this.KnobsFunction = KnobsFunctionEnum.Gain;
-            
+
             //if (!_settings.Controller.IsConnected)
             //{
             //    _midiController_ConnectionErrorEvent(this, null);
@@ -137,10 +137,10 @@ namespace UI24RController
             SendMessage("Try to reconnect....", false);
             if (!_isReconnecting)
             {
-                new Thread(() =>
+                new Thread(async () =>
                 {
                     _isReconnecting = true;
-                    while (_isReconnecting && !controller.ReConnectDevice())
+                    while (_isReconnecting && !await controller.ReConnectDevice())
                     {
                         Thread.Sleep(100);
                     }
@@ -179,7 +179,7 @@ namespace UI24RController
 
         private void Controller_TrackEvent(IMIDIController controller, EventArgs e)
         {
-            
+
         }
 
         private void Controller_PanEvent(IMIDIController controller, EventArgs e)
@@ -361,7 +361,7 @@ namespace UI24RController
                 SetControllerMuteButtonsForCurrentLayer();
             }
         }
-       
+
         private void _midiController_SelectChannelEvent(IMIDIController controller, MIDIController.ChannelEventArgs e)
         {
             var ch = _mixer.getChannelNumberInCurrentLayer(e.ChannelNumber, controller.ChannelOffset);
@@ -758,8 +758,8 @@ namespace UI24RController
         //these envent are public and provided to the secondary controller
         //if the selected channel is on the secondary controller the modified value has to be send back to the primary controller
 
-        public bool SelectedChannelIsOnCurrentLayer(int channelOffset) 
-        { 
+        public bool SelectedChannelIsOnCurrentLayer(int channelOffset)
+        {
                return _mixer.getCurrentLayer(channelOffset).Where(x => x == SelectedChannel).Count() > 0;
         }
         public int UserLayerEditNewChannel
@@ -833,7 +833,7 @@ namespace UI24RController
                 _mixer.setNewUserChannelInCurrentBank(controllerPos);
                 controller.WriteTextToChannelLCDSecondLine(controllerPos, "");
                 SetControllerChannelToCurrentLayerAndSend(controller, _mixer.UserLayerEditNewChannel, controllerPos);
-                
+
             }
         }
 
@@ -849,7 +849,7 @@ namespace UI24RController
                     _mixer.findNextAvailableChannelForUserLayer(controllerPos, e.WheelDirection, otherController.ChannelOffset);
                     controller.WriteTextToChannelLCDSecondLine(controllerPos, _mixerChannels[_mixer.UserLayerEditNewChannel].Name);
                 }
-                
+
             }
             //if (_secondaryBridge != null) _secondaryBridge._midiController_WheelEvent(sender, e);
         }
@@ -871,11 +871,11 @@ namespace UI24RController
             }
         }
 
-        
+
         #endregion
 
         private void InitializeChannels()
-        { 
+        {
             _mixerChannels = new List<ChannelBase>();
             for (int i=0; i<24; i++)
             {
@@ -966,7 +966,7 @@ namespace UI24RController
 
                 controller.SetSelectLed(controllerChannelNumber, false);
                 controller.SetKnobLed(controllerChannelNumber, 0);
-                                
+
                 controller.WriteTextToChannelLCDFirstLine(controllerChannelNumber, "");
                 controller.SetMuteLed(controllerChannelNumber, false);
                 controller.SetSoloLed(controllerChannelNumber, false);
@@ -1031,7 +1031,7 @@ namespace UI24RController
                 {
                     controller.SetLed(_selectedLayout.ToButtonsEnum(), true);
                     controller.WriteTextToBarsDisplay("AX" + (_selectedLayout.AuxToInt() + 1).ToString());
-                } 
+                }
                 else if (_selectedLayout.IsFx())
                 {
                     controller.SetLed(_selectedLayout.ToButtonsEnum(), true);
@@ -1039,7 +1039,7 @@ namespace UI24RController
                 }
 
             });
-                
+
         }
 
         private void SetKnobsFunctionLedOnController()
@@ -1091,7 +1091,7 @@ namespace UI24RController
                                         chOnLayer.controller.SetFader(chOnLayer.controllerChannelNumber, ui24Message.FaderValue);
                                     });
                                 }
-                                
+
                             }
                             break;
                         case MessageTypeEnum.name:
@@ -1359,7 +1359,7 @@ namespace UI24RController
         private void SetMuteGroupsLeds()
         {
             UInt32 mask = _mixer.MuteMask;
-            _controllers.ForEach(controller => { 
+            _controllers.ForEach(controller => {
                 for (int i = 0; i < 6; ++i)
                 {
                     controller.SetLed(ButtonsEnum.MuteGroup1 + i, ((mask >> i) & 1) == 1);

--- a/UI24RController/UI24RChannels/mixer.cs
+++ b/UI24RController/UI24RChannels/mixer.cs
@@ -42,7 +42,7 @@ namespace UI24RController.UI24RChannels
 
         private void initLayers(int startBank = 0)
         {
-          
+
             UserLayerEdit = false;
             UserLayerEditNewChannel = -1;
 
@@ -149,7 +149,7 @@ namespace UI24RController.UI24RChannels
             _banks[2][viewGroupNumber] = channels;
         }
 
-        public void setChannelInLayerAndPosition(int bank, int layerNumber, int position, int channel) 
+        public void setChannelInLayerAndPosition(int bank, int layerNumber, int position, int channel)
         {
             _banks[bank][layerNumber][position] = channel;
         }
@@ -213,7 +213,7 @@ namespace UI24RController.UI24RChannels
         {
             if (_selectedLayer < _banks[_selectedBank].Count)
             {
-                
+
                 if (_selectedBank<2)
                 {
                     var selectedLayer = (_selectedLayer + channelOffset) % _numLayersPerBank;
@@ -224,7 +224,7 @@ namespace UI24RController.UI24RChannels
                     var offset = channelOffset*8;
                     var result = _banks[_selectedBank][_selectedLayer].Skip(offset).Take(8).ToFixedLength(8,-1).Append(54);
                     return result.ToArray();
-                    
+
                 }
             }
             return new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 54 };
@@ -241,7 +241,7 @@ namespace UI24RController.UI24RChannels
         #region Mute Group
 
         private UInt32 _muteMask;
-        public UInt32 MuteMask { 
+        public UInt32 MuteMask {
             get
             {
                 return _muteMask;
@@ -300,7 +300,7 @@ namespace UI24RController.UI24RChannels
 
         #region Tap Tempo
 
-        private DateTime _lastTick;
+        private DateTime? _lastTick;
         private List<int> _tempo;
 
 
@@ -322,7 +322,7 @@ namespace UI24RController.UI24RChannels
                 return -1;
             }
 
-            double timeDiff = (newTick - _lastTick).TotalSeconds;
+            double timeDiff = (newTick - _lastTick.Value).TotalSeconds;
 
             //if tick after more than 5s, clear ticks
             if (timeDiff > 5)

--- a/UI24RController/UI24RController.csproj
+++ b/UI24RController/UI24RController.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This MR includes:

- A few small improvements to the reliability on linux:
  - Remove RtMidi references (not linux compatible)
  - Use async/await instead of blocking the thread during device connection
- Small bugfix: "first tap" logic wasn't working correctly due to `_lastTick` never being null. changing to `DateTime?` instead of `DateTime` ensures the check works
 - Update to .net 10.0
 - Small UX improvement: use numbers to select the MIDI device, instead of typing it out, e.g.:
  ```
Choose primary input device:
  [1]: Midi Through Port-0
  [2]: USB MIDI Interface
  [3]: X-Touch  
  [4]: X-Touch-ext
Enter number [1]: _
```
