### PR TITLE
Raspberry Pi - correct Midi Handling

### DIFF
--- a/Linux.md
+++ b/Linux.md
@@ -1,44 +1,3 @@
-# How to install UI24RBridge to Raspberry Pi
-
-- Install arm64 ubuntu linux to raspberry
-- Install .net Core 3.1 runtime from [here]( https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu)
-    - manual installation steps (article)[https://sumodh.com/2020/05/05/how-to-install-net-core-x64-sdk-in-raspberry-pi-4/?doing_wp_cron=1618749257.7842419147491455078125]:
-        - Download the Arm64 linux binaries from [here](https://dotnet.microsoft.com/download/dotnet/3.1)
-        - sudo mkdir -p $HOME/dotnet
-          sudo tar zxf dotnet-sdk-3.1.408-linux-arm.tar.gz -C $HOME/dotnet
-          export DOTNET_ROOT=$HOME/dotnet
-          export PATH=$PATH:$HOME/dotnet
-        - Add the two last row to the profle
-          sudo nano .profile
-
-Visual studio:
-sudo apt-get install code //visual studio
-dotnet:
-curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current
-echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
-echo 'export PATH=$PATH:$HOME/.dotnet' >> ~/.bashrc
-source ~/.bashrc
-
-
-sudo apt-get install libasound2-dev
-
-
-Manjaro linux
-sudo pacman -S git
-sudo pacman -S base-devel
-cd ~/Downloads
-git clone https://AUR.archlinux.org/visual-studio-code-bin.git
-cd visual-studio-code-bin/
-makepkg -s
-sudo pacman -U visual-studio-code-bin-1.52.1-1-aarch64.pkg.tar.zst
-
-.net core 3.1
-sudo mkdir -p $HOME/dotnet
-sudo tar zxf dotnet-sdk-3.1.100-linux-arm.tar.gz -C $HOME/dotnet
-export DOTNET_ROOT=$HOME/dotnet
-export PATH=$PATH:$HOME/dotnet
-
-
 # Raspberry PI CM5
 The most efficient approach is to use a Raspberry Pi CM5 with a carrier board
 (such as WaveShare CM5-IO-BASE-B) and a M.2 SSD to have the fastest boot times.
@@ -102,4 +61,27 @@ sudo reboot
 ```
 sudo systemctl disable --now NetworkManager-wait-online.service
 sudo systemctl mask NetworkManager-wait-online.service
+```
+
+## Build Ui24RBridge
+```
+# Install dependencies
+sudo apt install libasound2-dev
+
+# Install the .NET SDK
+wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+chmod +x ./dotnet-install.sh
+./dotnet-install.sh
+rm ./dotnet-install.sh
+echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
+echo 'export PATH=$PATH:$HOME/.dotnet' >> ~/.bashrc
+source ~/.bashrc
+
+# Clone the repository
+git clone https://github.com/MatthewInch/UI24RBridge.git
+
+# Build
+cd UI24RBridge/UI24RBridgeTest/
+dotnet build -c Release
+
 ```

--- a/Linux.md
+++ b/Linux.md
@@ -1,12 +1,12 @@
-# How to install UI24RBridge to raspberry PI
+# How to install UI24RBridge to Raspberry Pi
 
 - Install arm64 ubuntu linux to raspberry
 - Install .net Core 3.1 runtime from [here]( https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu)
     - manual installation steps (article)[https://sumodh.com/2020/05/05/how-to-install-net-core-x64-sdk-in-raspberry-pi-4/?doing_wp_cron=1618749257.7842419147491455078125]:
         - Download the Arm64 linux binaries from [here](https://dotnet.microsoft.com/download/dotnet/3.1)
-        - sudo mkdir -p $HOME/dotnet  
-          sudo tar zxf dotnet-sdk-3.1.408-linux-arm.tar.gz -C $HOME/dotnet  
-          export DOTNET_ROOT=$HOME/dotnet  
+        - sudo mkdir -p $HOME/dotnet
+          sudo tar zxf dotnet-sdk-3.1.408-linux-arm.tar.gz -C $HOME/dotnet
+          export DOTNET_ROOT=$HOME/dotnet
           export PATH=$PATH:$HOME/dotnet
         - Add the two last row to the profle
           sudo nano .profile
@@ -37,3 +37,69 @@ sudo mkdir -p $HOME/dotnet
 sudo tar zxf dotnet-sdk-3.1.100-linux-arm.tar.gz -C $HOME/dotnet
 export DOTNET_ROOT=$HOME/dotnet
 export PATH=$PATH:$HOME/dotnet
+
+
+# Raspberry PI CM5
+The most efficient approach is to use a Raspberry Pi CM5 with a carrier board
+(such as WaveShare CM5-IO-BASE-B) and a M.2 SSD to have the fastest boot times.
+
+## Hardware
+Below tested hardware configuration
+ - Raspberry Pi Compute Module 5, 16 GB RAM, Wireless
+ - M2 2242 size SSD, 128 GB (SK M2 NVME 2242 128GB)
+ - WaveShare CM5-IO-BASE-B carrier board
+ - Raspberry Pi Compute Module 5 Passive Cooler
+ - (Optional) Compute Module CM4/CM5 Antenna kit
+
+Install the M2 SSD and CM5 module with the provided screws.
+
+To fit the passive cooler, unscrew the fan that comes with the CM5-IO-BASE-B
+carrier board and position it outside the box, routing the cable back inside
+through one of the openings.
+
+The antenna kit is required to use WiFi, as the box will significantly
+attenuate any WiFi signals from reaching the onboard antenna. Note you
+must [update the raspberry pi configuration](https://www.jeffgeerling.com/blog/2022/enable-external-antenna-connector-on-raspberry-pi-compute-module-45/)
+to use the external antenna.
+
+## Flashing Raspberry Pi OS
+1. Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+2. Install or build the latest version of [rpiboot](https://github.com/raspberrypi/usbboot)
+(On Windows, download the installer available in the [releases](https://github.com/raspberrypi/usbboot/releases)
+page)
+3. Plug a USB-C cable to your PC while holding down the `BOOT` button. In
+other carrier boards, instead, place a jumper between `nRPIBOOT` and `GND`
+(J2 pins 1-2 in the official CM5 carrier board) before plugging in the
+USB-C cable.
+4. Run `sudo rpiboot` (On windows, launch `rpi-mass-storage-gadget64.bat`).
+This should mount a writeable USB drive on which we'll write the OS image.
+5. Flash the image using the Raspberry Pi Imager utility. (Recommended to use 64-bit
+Raspberry Pi OS)
+
+Source: https://www.waveshare.com/wiki/Compute_Module_Burn_EMMC
+
+## Boot time Tweaks
+A few optional tweaks to improve boot times.
+
+1. Ensure everything is up to date
+```
+sudo apt update && sudo apt full-upgrade
+```
+
+2. Update bootloader and reboot:
+```
+sudo rpi-eeprom-update -a
+sudo reboot
+```
+
+3. Change the boot order to prefer NVMe:
+    - Open the Raspberry Pi configuration editor (`sudo raspi-config`)
+    - Navigate to `Advanced Options` > `Boot` > `Boot Order`
+    - Highlight `NVMe/USB Boot` and press enter
+    - Follow the prompts
+
+4. Disable network wait:
+```
+sudo systemctl disable --now NetworkManager-wait-online.service
+sudo systemctl mask NetworkManager-wait-online.service
+```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Bridge between the UI24R and a MIDI controllers. Current version can manage one or two controller. If you want to use more you can run more bridge instance.\
 This is a beta project. It tested only on Windows with Behringer X-Touch and X-Touch extender MIDI controllers.
 
-You can download the [latest release here](https://github.com/MatthewInch/UI24RBridge/releases/latest).
-The Linux binary not work in 32bit linux and instabil in 64bit versions
-The MacOS binary wasn't tested
+You can download the [latest release here](https://github.com/MatthewInch/UI24RBridge/releases/latest). Note that the MacOS binary wasn't tested.
+
+For Raspberry Pi or other linux distributions, see instructions [here](Linux.md)
 
 Implemented the Mackie Control protocol (It can work with any DAW controller that can use in MC mode).\
 The earlier protocol has not been removed but the new functions only implemented in MC mode.
@@ -89,7 +89,7 @@ In the settings file (**appsettings.json**):
 	"PrimaryIsExtender": "false",\
 	"SecondaryIsExtender": "true",\
 	"PrimaryChannelStart": "0", //0: 1-8ch, 1: 9-16\
-	"SecondaryChannelStart": "1", //0: 1-8ch, 1: 9-16\	
+	"SecondaryChannelStart": "1", //0: 1-8ch, 1: 9-16\
     "Protocol": "MC",\
     "SyncID": "Abaliget",\
     "DefaultRecButton": "2TrackAndMTK",\

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -33,6 +33,12 @@ namespace UI24RController.MIDIController
                 IsTouched = false;
             }
         }
+
+        /// <summary>
+        /// Keep track of last MIDI status byte
+        /// </summary>
+        protected byte? _lastMidiStatus;
+
         /// <summary>
         /// Store every fader setted value of the faders, key is the channel number (z in the message)
         /// </summary>
@@ -156,6 +162,56 @@ namespace UI24RController.MIDIController
             //byte[] sysex = new byte[] { 0xf0, 0, 0, 0x66, 0x14, 0x61, 0xf7 };
             //Send(sysex, 0, sysex.Length, 0);
         }
+
+        protected byte[] NormalizeRunningStatus(byte[] data)
+        {
+            if (data == null || data.Length == 0)
+            {
+                return data;
+            }
+
+            var first = data[0];
+
+            // If the first byte is a status byte, track it, depending on type
+            // See: https://studiocode.dev/kb/MIDI/midi/
+            //   Channel messages can have running status. That is, if the next
+            //   channel status byte is the same as the last, it may be omitted.
+            //   The receiver assumes that the accompanying data is of the same
+            //   status as was last sent. Receipt of any other status byte except
+            //   real-time terminates running status.
+            if ((first & 0x80) != 0)
+            {
+                // Channel voice messages: valid running status
+                if (first >= 0x80 && first <= 0xEF)
+                {
+                    _lastMidiStatus = first;
+                }
+                // System exclusive / system common: cancel running status
+                else if (first >= 0xF0 && first <= 0xF7)
+                {
+                    _lastMidiStatus = null;
+                }
+                // System real-time: leave running status unchanged
+                else if (first >= 0xF8)
+                {
+                    // no change
+                }
+
+                return data;
+            }
+
+            // If the first byte is data, rebuild the message using the last known status.
+            if (_lastMidiStatus is byte status)
+            {
+                var normalized = new byte[data.Length + 1];
+                normalized[0] = status;
+                Buffer.BlockCopy(data, 0, normalized, 1, data.Length);
+                return normalized;
+            }
+
+            return data;
+        }
+
         protected void OnMessageReceived(string message)
         {
             MessageReceived?.Invoke(this, new MessageEventArgs(message));
@@ -425,6 +481,7 @@ namespace UI24RController.MIDIController
 
         public async Task<bool> ConnectInputDevice(string deviceName)
         {
+            _lastMidiStatus = null;
             try
             {
                 _inputDeviceName = deviceName;
@@ -438,9 +495,8 @@ namespace UI24RController.MIDIController
                     _inputDeviceNumber = deviceNumber.Id;
                     _input.MessageReceived += (obj, e) =>
                     {
-                        if (e.Data.Length > 2)
+                        if (e.Data.Length > 0)
                         {
-                            OnMessageReceived($"{e.Data[0].ToString("x2")} - {e.Data[1].ToString("x2")} - {e.Data[2].ToString("x2")}");
                             ProcessMidiMessage(e);
                         }
                     };
@@ -538,7 +594,14 @@ namespace UI24RController.MIDIController
         }
         private void ProcessMidiMessage(MidiReceivedEventArgs e)
         {
-            var message = e.Data;
+            var message = NormalizeRunningStatus(e.Data);
+
+            if (message == null || message.Length < 3)
+            {
+                return;
+            }
+
+            OnMessageReceived($"{message[0]:x2} - {message[1]:x2} - {message[2]:x2}");
 
             if (message[0] == 0x90) //button pressed, released, fader released
             {
@@ -812,7 +875,7 @@ namespace UI24RController.MIDIController
                 }
 
             }
-            else if (message[0] == 0xb0 && (message[1] >= 0x10 && message[1] <= 0x17)) //channel knobb turning
+            else if (message[0] == 0xb0 && message[1] >= 0x10 && message[1] <= 0x17) //channel knobb turning
             {
                 byte channelNumber = (byte)(message[1] - 0x10);
                 if (message[2] >= 0x01 && message[2] <= 0x03)

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -461,22 +461,31 @@ namespace UI24RController.MIDIController
         public void Dispose()
         {
             _isConnected = false;
+
             if (_pingThread != null)
             {
-                //stop the pinging thread
                 _isConnectionErrorOccured = true;
             }
+
+            // On linux, input and output ports might be the same device. The input
+            // port owns the resource and should be the one to dispose it
+
+            bool samePort = _input != null && _output != null
+                    && _input.Details?.Id == _output.Details?.Id;
+
+            if (_output != null && !samePort)
+            {
+                _output.Dispose();
+            }
+
+            _output = null;
+
+
             if (_input != null)
             {
                 _input.Dispose();
                 _input = null;
             }
-            if (_output != null)
-            {
-                _output.Dispose();
-                _output = null;
-            }
-
         }
 
         public async Task<bool> ConnectInputDevice(string deviceName)

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -437,23 +437,13 @@ namespace UI24RController.MIDIController
 
         protected void OnConnectionErrorEvent()
         {
-            if (ConnectionErrorEvent != null )
-            {
-                _isConnectionErrorOccured = true;
-                _isConnected = false;
-                ConnectionErrorEvent(this, new EventArgs());
-            }
+            _isConnectionErrorOccured = true;
+            _isConnected = false;
+            ConnectionErrorEvent?.Invoke(this, new EventArgs());
         }
 
-        public void Dispose()
+        private void DisposePorts()
         {
-            _isConnected = false;
-
-            if (_pingThread != null)
-            {
-                _isConnectionErrorOccured = true;
-            }
-
             // On linux, input and output ports might be the same device. The input
             // port owns the resource and should be the one to dispose it
 
@@ -473,6 +463,19 @@ namespace UI24RController.MIDIController
                 _input.Dispose();
                 _input = null;
             }
+        }
+
+
+        public void Dispose()
+        {
+            _isConnected = false;
+
+            if (_pingThread != null)
+            {
+                _isConnectionErrorOccured = true;
+            }
+
+            DisposePorts();
         }
 
         public async Task<bool> ConnectInputDevice(string deviceName)
@@ -546,10 +549,23 @@ namespace UI24RController.MIDIController
                 {
                     while (!_isConnectionErrorOccured)
                     {
-                        Thread.Sleep(5000);
-                        Send(new byte[] { 0xb0, 0x00, 0x00 }, 0, 3, 0);
+                        Thread.Sleep(1000);
+
+                        bool deviceStillPresent = MidiAccessManager.Default.Inputs
+                            .Any(i => i.Name.ToUpper() == _inputDeviceName.ToUpper());
+
+                        if (!deviceStillPresent)
+                        {
+                            OnConnectionErrorEvent();
+                        }
+                        else
+                        {
+                            Send(new byte[] { 0xb0, 0x00, 0x00 }, 0, 3, 0);
+                        }
                     }
                 });
+
+                _pingThread.IsBackground = true;
             }
             if (!_pingThread.IsAlive)
                 _pingThread.Start();
@@ -557,6 +573,7 @@ namespace UI24RController.MIDIController
         }
         public async Task<bool> ReConnectDevice()
         {
+            DisposePorts();
             var inputOk  = await ConnectInputDevice(_inputDeviceName);
             var outputOk = await ConnectOutputDevice(_outputDeviceName);
             return inputOk && outputOk;

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -163,53 +163,40 @@ namespace UI24RController.MIDIController
             //Send(sysex, 0, sysex.Length, 0);
         }
 
-        protected byte[] NormalizeRunningStatus(byte[] data)
+        protected IEnumerable<byte[]> NormalizeAndSplitMidiMessages(byte[] data, int start, int length)
         {
-            if (data == null || data.Length == 0)
-            {
-                return data;
-            }
+            int i = start;
+            int end = start + length;
 
-            var first = data[0];
-
-            // If the first byte is a status byte, track it, depending on type
-            // See: https://studiocode.dev/kb/MIDI/midi/
-            //   Channel messages can have running status. That is, if the next
-            //   channel status byte is the same as the last, it may be omitted.
-            //   The receiver assumes that the accompanying data is of the same
-            //   status as was last sent. Receipt of any other status byte except
-            //   real-time terminates running status.
-            if ((first & 0x80) != 0)
+            while (i < end)
             {
-                // Channel voice messages: valid running status
-                if (first >= 0x80 && first <= 0xEF)
+                byte first = data[i];
+
+                // If the first byte is a status byte, track it, depending on type
+                // See: https://studiocode.dev/kb/MIDI/midi/
+                //   Channel messages can have running status. That is, if the next
+                //   channel status byte is the same as the last, it may be omitted.
+                //   The receiver assumes that the accompanying data is of the same
+                //   status as was last sent. Receipt of any other status byte except
+                //   real-time terminates running status.
+
+                if ((first & 0x80) != 0)
                 {
+                    // Status byte present: full 3-byte message
                     _lastMidiStatus = first;
+                    if (i + 3 > end) yield break;
+                    yield return new byte[] { data[i], data[i + 1], data[i + 2] };
+                    i += 3;
                 }
-                // System exclusive / system common: cancel running status
-                else if (first >= 0xF0 && first <= 0xF7)
+                else
                 {
-                    _lastMidiStatus = null;
+                    // Running status: 2 data bytes, prepend last known status
+                    if (_lastMidiStatus == null) { i++; continue; } // no known status, skip
+                    if (i + 2 > end) yield break;
+                    yield return new byte[] { _lastMidiStatus.Value, data[i], data[i + 1] };
+                    i += 2;
                 }
-                // System real-time: leave running status unchanged
-                else if (first >= 0xF8)
-                {
-                    // no change
-                }
-
-                return data;
             }
-
-            // If the first byte is data, rebuild the message using the last known status.
-            if (_lastMidiStatus is byte status)
-            {
-                var normalized = new byte[data.Length + 1];
-                normalized[0] = status;
-                Buffer.BlockCopy(data, 0, normalized, 1, data.Length);
-                return normalized;
-            }
-
-            return data;
         }
 
         protected void OnMessageReceived(string message)
@@ -603,301 +590,294 @@ namespace UI24RController.MIDIController
         }
         private void ProcessMidiMessage(MidiReceivedEventArgs e)
         {
-            var message = NormalizeRunningStatus(e.Data);
-
-            if (message == null || message.Length < 3)
+            foreach (var message in NormalizeAndSplitMidiMessages(e.Data, e.Start, e.Length))
             {
-                return;
-            }
-
-            OnMessageReceived($"{message[0]:x2} - {message[1]:x2} - {message[2]:x2}");
-
-            if (message[0] == 0x90) //button pressed, released, fader released
-            {
-                if (message.MIDIEqual(0x90, 0x00, 0x00, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //release fader (0x90 [0x68-0x70] 0x00)
+                if (message[0] == 0x90) //button pressed, released, fader released
                 {
-                    byte channelNumber = (byte)(message[1] - 0x68);
-                    if (faderValues.ContainsKey(channelNumber))
+                    if (message.MIDIEqual(0x90, 0x00, 0x00, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //release fader (0x90 [0x68-0x70] 0x00)
                     {
-                        faderValues[channelNumber].IsTouched = false;
-                        SetFader(channelNumber, faderValues[channelNumber].Value);
-                    }
-                }
-                if (message.MIDIEqual(0x90, 0x00, 0x7f, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //touch fader (0x90 [0x68-0x70] 0x00)
-                {
-                    byte channelNumber = (byte)(message[1] - 0x68);
-                    if (faderValues.ContainsKey(channelNumber))
-                    {
-                        faderValues[channelNumber].IsTouched = true;
-                    }
-                }
-
-                else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Mute] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Mute] + 7) && message[2] == 0x7f) //channel mute button
-                {
-                    byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Mute]);
-                    OnChannelMuteEvent(channelNumber);
-                }
-                else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Solo] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Solo] + 7) && message[2] == 0x7f) //channel solo button
-                {
-                    byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Solo]);
-                    OnChannelSoloEvent(channelNumber);
-                }
-                else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Rec] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Rec] + 7) && message[2] == 0x7f) //channel rec button
-                {
-                    byte channelNumber = (byte)(message[1]- _buttonsID[ButtonsEnum.Ch1Rec]);
-                    OnChannelRecEvent(channelNumber);
-                }
-                else if  (message[1] >= _buttonsID[ButtonsEnum.Ch1Select] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Select] + 7) && message[2] == 0x7f) //channel select button
-                {
-                    byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Select]);
-                    OnChannelSelectEvent(channelNumber);
-                }
-                else if (message.MIDIEqual(0x90, 0x32, 0x7f)) //main select button
-                {
-                    OnChannelSelectEvent(8);
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Track], 0x7f))
-                {
-                    OnTrackEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Pan], 0x7f))
-                {
-                    OnPanEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Eq], 0x7f))
-                {
-                    OnEqEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Send], 0x7f))
-                {
-                    OnSendEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlugIn], 0x7f))
-                {
-                    OnPlugInEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Instr], 0x7f))
-                {
-                    OnInstrEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Display], 0x7f))
-                {
-                    OnDisplayBtnEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Smtpe], 0x7f))
-                {
-                    OnSmtpeBeatsBtnEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.GlobalView], 0x7f))
-                {
-                    OnGlobalViewEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.MidiTracks], 0x7f))
-                {
-                    OnMidiTracksEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Inputs], 0x7f))
-                {
-                    OnInputsEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioTracks], 0x7f))
-                {
-                    OnAudioTracksEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioInst], 0x7f))
-                {
-                    OnAudioInstEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AuxBtn], 0x7f))
-                {
-                    OnAuxBtnEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.BusesBtn], 0x7f))
-                {
-                    OnBusesBtnEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Outputs], 0x7f))
-                {
-                    OnOutputsEvent();
-                }
-                else if ((message[0] == 0x90) && message[1] == _buttonsID[ButtonsEnum.User])
-                {
-                    OnUserEvent(0, message[2] == 0x7f);
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Save], 0x7f))
-                {
-                    OnSaveEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Undo], 0x7f))
-                {
-                    OnUndoEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cancel], 0x7f))
-                {
-                    OnCancelEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Enter], 0x7f))
-                {
-                    OnEnterEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Marker], 0x7f))
-                {
-                    OnMarkerEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Nudge], 0x7f))
-                {
-                    OnNudgeEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cycle], 0x7f))
-                {
-                    OnCycleEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Drop], 0x7f))
-                {
-                    OnDropEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Replace], 0x7f))
-                {
-                    OnReplaceEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Click], 0x7f))
-                {
-                    OnClickEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Solo], 0x7f))
-                {
-                    OnSoloEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayPrev], 0x7f))
-                {
-                    OnPrevEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayNext], 0x7f))
-                {
-                    OnNextEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Stop], 0x7f))
-                {
-                    OnStopEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Play], 0x7f))
-                {
-                    OnPlayEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Rec], 0x7f))
-                {
-                    OnRecEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankUp], 0x7f))
-                {
-                    OnBankUp();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankDown], 0x7f))
-                {
-                    OnBankDown();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelUp], 0x7f))
-                {
-                    OnLayerUp();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelDown], 0x7f))
-                {
-                    OnLayerDown();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Up], 0x7f))
-                {
-                    OnUpEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Down], 0x7f))
-                {
-                    OnDownEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Left], 0x7f))
-                {
-                    OnLeftEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Right], 0x7f))
-                {
-                    OnRightEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Center], 0x7f))
-                {
-                    OnCenterEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x00))
-                {
-                    OnScrubEvent(true);
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x7f))
-                {
-                    OnScrubEvent(false);
-                }
-
-                else if (message[0]== 0x90 && _buttonsID.GetAuxButton(message[1]).isAux) //F1-F8 press
-                {
-                    var auxNum = _buttonsID.GetAuxButton(message[1]).auxNum;
-                    OnAuxButtonEvent(auxNum, message[2] == 0x7f);
-                }
-                else if ((message[0] == 0x90) && _buttonsID.GetFxButton(message[1]).isFX)
-                {
-                    var fxNum = _buttonsID.GetFxButton(message[1]).fxNum;
-                    OnFxButtonEvent(fxNum, message[2] == 0x7f);
-                }
-                else if ((message[0] == 0x90) && _buttonsID.GetMuteGroupsButton(message[1]).isMuteGroupButton)
-                {
-                    var muteNum = _buttonsID.GetMuteGroupsButton(message[1]).muteGroupNum;
-                    OnMuteGroupButtonEvent(muteNum, message[2] == 0x7f);
-                }
-
-            }
-            else if (message[0] >= 0xe0 && (message[0] <= 0xe8)) //move fader
-            {
-                byte channelNumber = (byte)(message[0] - 0xe0);
-                //int data2 = (int)Math.Round(faderValue * 1023); //10 bit
-                int upper = message[2] << 7; //upper 7 bit
-                int lower = message[1]; // lower 7 bit
-
-                var faderValue = (upper + lower) / 16383.0;
-
-                faderValues[channelNumber].Value = faderValue;
-                OnFaderEvent(channelNumber, faderValue);
-                if (!faderValues[channelNumber].IsTouched)
-                {
-                    new Thread(() =>
-                    {
-                        Thread.Sleep(100);
-                        //if value change the other thread write back the last fader value
-                        if (faderValue == faderValues[channelNumber].Value)
+                        byte channelNumber = (byte)(message[1] - 0x68);
+                        if (faderValues.ContainsKey(channelNumber))
                         {
-                            SetFader(channelNumber, faderValue);
+                            faderValues[channelNumber].IsTouched = false;
+                            SetFader(channelNumber, faderValues[channelNumber].Value);
                         }
-                    }).Start();
-                }
+                    }
+                    else if (message.MIDIEqual(0x90, 0x00, 0x7f, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //touch fader (0x90 [0x68-0x70] 0x00)
+                    {
+                        byte channelNumber = (byte)(message[1] - 0x68);
+                        if (faderValues.ContainsKey(channelNumber))
+                        {
+                            faderValues[channelNumber].IsTouched = true;
+                        }
+                    }
+                    else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Mute] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Mute] + 7) && message[2] == 0x7f) //channel mute button
+                    {
+                        byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Mute]);
+                        OnChannelMuteEvent(channelNumber);
+                    }
+                    else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Solo] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Solo] + 7) && message[2] == 0x7f) //channel solo button
+                    {
+                        byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Solo]);
+                        OnChannelSoloEvent(channelNumber);
+                    }
+                    else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Rec] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Rec] + 7) && message[2] == 0x7f) //channel rec button
+                    {
+                        byte channelNumber = (byte)(message[1]- _buttonsID[ButtonsEnum.Ch1Rec]);
+                        OnChannelRecEvent(channelNumber);
+                    }
+                    else if  (message[1] >= _buttonsID[ButtonsEnum.Ch1Select] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Select] + 7) && message[2] == 0x7f) //channel select button
+                    {
+                        byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Select]);
+                        OnChannelSelectEvent(channelNumber);
+                    }
+                    else if (message.MIDIEqual(0x90, 0x32, 0x7f)) //main select button
+                    {
+                        OnChannelSelectEvent(8);
+                    }
 
-            }
-            else if (message[0] == 0xb0 && message[1] >= 0x10 && message[1] <= 0x17) //channel knobb turning
-            {
-                byte channelNumber = (byte)(message[1] - 0x10);
-                if (message[2] >= 0x01 && message[2] <= 0x03)
-                    OnKnobEvent(channelNumber, message[2]);
-                if (message[2] >= 0x41 && message[2] <= 0x43)
-                    OnKnobEvent(channelNumber, -1 * (message[2] & 0x03));
-            }
-            else if (message[0] == 0xb0 && message[1] == 0x3c ) //jog wheel turning
-            {
-                if (message[2] >= 0x01 && message[2] <= 0x03)
-                    OnWheelEvent(0, message[2]);
-                if (message[2] >= 0x41 && message[2] <= 0x43)
-                    OnWheelEvent(0, -1 * (message[2] & 0x03));
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Track], 0x7f))
+                    {
+                        OnTrackEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Pan], 0x7f))
+                    {
+                        OnPanEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Eq], 0x7f))
+                    {
+                        OnEqEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Send], 0x7f))
+                    {
+                        OnSendEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlugIn], 0x7f))
+                    {
+                        OnPlugInEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Instr], 0x7f))
+                    {
+                        OnInstrEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Display], 0x7f))
+                    {
+                        OnDisplayBtnEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Smtpe], 0x7f))
+                    {
+                        OnSmtpeBeatsBtnEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.GlobalView], 0x7f))
+                    {
+                        OnGlobalViewEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.MidiTracks], 0x7f))
+                    {
+                        OnMidiTracksEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Inputs], 0x7f))
+                    {
+                        OnInputsEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioTracks], 0x7f))
+                    {
+                        OnAudioTracksEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioInst], 0x7f))
+                    {
+                        OnAudioInstEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AuxBtn], 0x7f))
+                    {
+                        OnAuxBtnEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.BusesBtn], 0x7f))
+                    {
+                        OnBusesBtnEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Outputs], 0x7f))
+                    {
+                        OnOutputsEvent();
+                    }
+                    else if ((message[0] == 0x90) && message[1] == _buttonsID[ButtonsEnum.User])
+                    {
+                        OnUserEvent(0, message[2] == 0x7f);
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Save], 0x7f))
+                    {
+                        OnSaveEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Undo], 0x7f))
+                    {
+                        OnUndoEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cancel], 0x7f))
+                    {
+                        OnCancelEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Enter], 0x7f))
+                    {
+                        OnEnterEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Marker], 0x7f))
+                    {
+                        OnMarkerEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Nudge], 0x7f))
+                    {
+                        OnNudgeEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cycle], 0x7f))
+                    {
+                        OnCycleEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Drop], 0x7f))
+                    {
+                        OnDropEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Replace], 0x7f))
+                    {
+                        OnReplaceEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Click], 0x7f))
+                    {
+                        OnClickEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Solo], 0x7f))
+                    {
+                        OnSoloEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayPrev], 0x7f))
+                    {
+                        OnPrevEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayNext], 0x7f))
+                    {
+                        OnNextEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Stop], 0x7f))
+                    {
+                        OnStopEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Play], 0x7f))
+                    {
+                        OnPlayEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Rec], 0x7f))
+                    {
+                        OnRecEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankUp], 0x7f))
+                    {
+                        OnBankUp();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankDown], 0x7f))
+                    {
+                        OnBankDown();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelUp], 0x7f))
+                    {
+                        OnLayerUp();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelDown], 0x7f))
+                    {
+                        OnLayerDown();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Up], 0x7f))
+                    {
+                        OnUpEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Down], 0x7f))
+                    {
+                        OnDownEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Left], 0x7f))
+                    {
+                        OnLeftEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Right], 0x7f))
+                    {
+                        OnRightEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Center], 0x7f))
+                    {
+                        OnCenterEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x00))
+                    {
+                        OnScrubEvent(true);
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x7f))
+                    {
+                        OnScrubEvent(false);
+                    }
+
+                    else if (message[0]== 0x90 && _buttonsID.GetAuxButton(message[1]).isAux) //F1-F8 press
+                    {
+                        var auxNum = _buttonsID.GetAuxButton(message[1]).auxNum;
+                        OnAuxButtonEvent(auxNum, message[2] == 0x7f);
+                    }
+                    else if ((message[0] == 0x90) && _buttonsID.GetFxButton(message[1]).isFX)
+                    {
+                        var fxNum = _buttonsID.GetFxButton(message[1]).fxNum;
+                        OnFxButtonEvent(fxNum, message[2] == 0x7f);
+                    }
+                    else if ((message[0] == 0x90) && _buttonsID.GetMuteGroupsButton(message[1]).isMuteGroupButton)
+                    {
+                        var muteNum = _buttonsID.GetMuteGroupsButton(message[1]).muteGroupNum;
+                        OnMuteGroupButtonEvent(muteNum, message[2] == 0x7f);
+                    }
+
+                }
+                else if (message[0] >= 0xe0 && (message[0] <= 0xe8)) //move fader
+                {
+                    byte channelNumber = (byte)(message[0] - 0xe0);
+                    //int data2 = (int)Math.Round(faderValue * 1023); //10 bit
+                    int upper = message[2] << 7; //upper 7 bit
+                    int lower = message[1]; // lower 7 bit
+
+                    var faderValue = (upper + lower) / 16383.0;
+
+                    faderValues[channelNumber].Value = faderValue;
+                    OnFaderEvent(channelNumber, faderValue);
+                    if (!faderValues[channelNumber].IsTouched)
+                    {
+                        new Thread(() =>
+                        {
+                            Thread.Sleep(100);
+                            //if value change the other thread write back the last fader value
+                            if (faderValue == faderValues[channelNumber].Value)
+                            {
+                                SetFader(channelNumber, faderValue);
+                            }
+                        }).Start();
+                    }
+
+                }
+                else if (message[0] == 0xb0 && message[1] >= 0x10 && message[1] <= 0x17) //channel knobb turning
+                {
+                    byte channelNumber = (byte)(message[1] - 0x10);
+                    if (message[2] >= 0x01 && message[2] <= 0x03)
+                        OnKnobEvent(channelNumber, message[2]);
+                    if (message[2] >= 0x41 && message[2] <= 0x43)
+                        OnKnobEvent(channelNumber, -1 * (message[2] & 0x03));
+                }
+                else if (message[0] == 0xb0 && message[1] == 0x3c ) //jog wheel turning
+                {
+                    if (message[2] >= 0x01 && message[2] <= 0x03)
+                        OnWheelEvent(0, message[2]);
+                    if (message[2] >= 0x41 && message[2] <= 0x43)
+                        OnWheelEvent(0, -1 * (message[2] & 0x03));
+                }
             }
         }
 

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -22,6 +22,7 @@ namespace UI24RController
 
         const string CONFIGFILE_VIEW_GROUP = "ViewGroups.json";
 
+        private readonly HashSet<IMIDIController> _reconnectingControllers = new HashSet<IMIDIController>();
         protected BridgeSettings _settings;
         protected List<IMIDIController> _controllers;
         protected WebsocketClient _client;
@@ -134,29 +135,38 @@ namespace UI24RController
         private void _midiController_ConnectionErrorEvent(IMIDIController controller, EventArgs e)
         {
             SendMessage("Midi controller connection error.", false);
-            SendMessage("Try to reconnect....", false);
-            if (!_isReconnecting)
+
+            lock (_reconnectingControllers)
             {
-                new Thread(async () =>
+                if (_reconnectingControllers.Contains(controller))
                 {
-                    _isReconnecting = true;
-                    while (_isReconnecting && !await controller.ReConnectDevice())
-                    {
-                        Thread.Sleep(100);
-                    }
-
-                    SetControllerToCurrentLayerAndSend();
-                    SetStateLedsOnController();
-
-                    SendMessage("Midi controller reconnected.", false);
-                    _isReconnecting = false;
-                }).Start();
+                    SendMessage("Reconnection already in progress for this controller.");
+                    return;
+                }
+                _reconnectingControllers.Add(controller);
             }
-            else
+
+            SendMessage("Try to reconnect....", false);
+
+            new Thread(async () =>
             {
-                SendMessage("Reconnection state is true...");
-            }
-        }
+                while (!await controller.ReConnectDevice())
+                {
+                    Thread.Sleep(200);
+                }
+
+                controller.InitializeController();
+                SetControllerToCurrentLayerAndSend();
+                SetStateLedsOnController();
+
+                SendMessage("Midi controller reconnected.", false);
+
+                lock (_reconnectingControllers)
+                {
+                    _reconnectingControllers.Remove(controller);
+                }
+            }).Start();
+    }
         private void WebsocketReconnectionHappened(ReconnectionInfo info)
         {
             _controllers.ForEach(c=> c.WriteTextToLCDSecondLine("UI24R is reconnected",5));

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -201,12 +201,23 @@ namespace UI24RController
     }
         private void WebsocketReconnectionHappened(ReconnectionInfo info)
         {
-            _controllers.ForEach(c=> c.WriteTextToLCDSecondLine("UI24R is reconnected",5));
+            if (info.Type != ReconnectionType.Initial)
+                _controllers.ForEach(c => c.WriteTextToLCDSecondLine("UI24R is reconnected", 5));
+
+            Task.Run(async () =>
+            {
+                await Task.Delay(500); // Wait for Ui24R to send us all data
+                SetControllerToCurrentLayerAndSend();
+                SetStateLedsOnController();
+                SendMessage("Mixer state synced to controller.", false);
+            });
         }
+
         private void WebsocketDisconnectionHappened(DisconnectionInfo info)
         {
             _controllers.ForEach(c => c.WriteTextToLCDSecondLine("UI24R disconnected. Try to reconnect"));
         }
+
         private void InitializeViewGroupsFromConfig()
         {
             if (File.Exists(CONFIGFILE_VIEW_GROUP))

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using System.Net.WebSockets;
 using System.Threading;
 using UI24RController.UI24RChannels;
@@ -114,14 +115,28 @@ namespace UI24RController
             //    _midiController_ConnectionErrorEvent(this, null);
             //}
             _mixer.setBank(_settings.StartBank);
-            SendMessage("Start websocket connection...", false);
-            _client = new WebsocketClient(new Uri(_settings.Address));
-            _client.MessageReceived.Subscribe(msg => UI24RMessageReceived(msg));
-            _client.DisconnectionHappened.Subscribe(info => WebsocketDisconnectionHappened(info));
-            _client.ReconnectionHappened.Subscribe(info => WebsocketReconnectionHappened(info));
-            _client.ErrorReconnectTimeout = new TimeSpan(0,0,10);
-            SendMessage("Connecting to UI24R....", false);
-            _client.Start();
+
+            Task.Run(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        _client = _createWebsocketClient();
+                        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                        await _client.Start().WaitAsync(cts.Token);
+                        SendMessage($"UI24R connected.", false);
+                        break;
+                    }
+                    catch
+                    {
+                        SendMessage($"UI24R not reachable, retrying in 5 seconds...", false);
+                        try { _client.Dispose(); } catch { }
+                        await Task.Delay(5000);
+                    }
+                }
+            });
+
             controllers.ForEach(c=> c.WriteTextToAssignmentDisplay(_mixer.getCurrentLayerString()));
             //if (settings.ControllerStartChannel != null && settings.ControllerStartChannel == "1")
             //{
@@ -130,6 +145,23 @@ namespace UI24RController
             SetStateLedsOnController();
         }
 
+
+        private WebsocketClient _createWebsocketClient()
+        {
+            var client = new WebsocketClient(new Uri(_settings.Address), () =>
+            {
+                var socket = new ClientWebSocket();
+                socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(1);
+                return socket;
+            });
+            client.ReconnectTimeout = TimeSpan.FromSeconds(5);
+            client.ErrorReconnectTimeout = TimeSpan.FromSeconds(5);
+            client.IsReconnectionEnabled = true;
+            client.MessageReceived.Subscribe(msg => UI24RMessageReceived(msg));
+            client.DisconnectionHappened.Subscribe(info => WebsocketDisconnectionHappened(info));
+            client.ReconnectionHappened.Subscribe(info => WebsocketReconnectionHappened(info));
+            return client;
+        }
 
 
         private void _midiController_ConnectionErrorEvent(IMIDIController controller, EventArgs e)


### PR DESCRIPTION
With this MR, a Raspberry PI CM5 can now be used reliably with the `managed-midi` library.

 - Fixes the way Midi messages should be handled using the Linux implementation of `managed-midi`:
    - Properly handle the omission of status byte if equal to last (ref https://github.com/atsushieno/managed-midi/issues/79 )
    - Handle more than one midi message per frame (slicing midi messages together)
 - Correctly detect and handle MIDI device disconnection on linux. Unfortunately ALSA doesn't throw when a message is sent to a non-existant device - it silently fails - we need to poll for device existance.
 - Improvements to initial connection reliability (Added 500ms delay on initial reconnection before re-synchronising the control surface)
 - Better detection of connection loss (shorter timeouts)
 - Added detailed instructions for raspberry pi setup.