### PR TITLE
Various Fixes and Improvements

### DIFF
--- a/Linux.md
+++ b/Linux.md
@@ -1,44 +1,3 @@
-# How to install UI24RBridge to Raspberry Pi
-
-- Install arm64 ubuntu linux to raspberry
-- Install .net Core 3.1 runtime from [here]( https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu)
-    - manual installation steps (article)[https://sumodh.com/2020/05/05/how-to-install-net-core-x64-sdk-in-raspberry-pi-4/?doing_wp_cron=1618749257.7842419147491455078125]:
-        - Download the Arm64 linux binaries from [here](https://dotnet.microsoft.com/download/dotnet/3.1)
-        - sudo mkdir -p $HOME/dotnet
-          sudo tar zxf dotnet-sdk-3.1.408-linux-arm.tar.gz -C $HOME/dotnet
-          export DOTNET_ROOT=$HOME/dotnet
-          export PATH=$PATH:$HOME/dotnet
-        - Add the two last row to the profle
-          sudo nano .profile
-
-Visual studio:
-sudo apt-get install code //visual studio
-dotnet:
-curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current
-echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
-echo 'export PATH=$PATH:$HOME/.dotnet' >> ~/.bashrc
-source ~/.bashrc
-
-
-sudo apt-get install libasound2-dev
-
-
-Manjaro linux
-sudo pacman -S git
-sudo pacman -S base-devel
-cd ~/Downloads
-git clone https://AUR.archlinux.org/visual-studio-code-bin.git
-cd visual-studio-code-bin/
-makepkg -s
-sudo pacman -U visual-studio-code-bin-1.52.1-1-aarch64.pkg.tar.zst
-
-.net core 3.1
-sudo mkdir -p $HOME/dotnet
-sudo tar zxf dotnet-sdk-3.1.100-linux-arm.tar.gz -C $HOME/dotnet
-export DOTNET_ROOT=$HOME/dotnet
-export PATH=$PATH:$HOME/dotnet
-
-
 # Raspberry PI CM5
 The most efficient approach is to use a Raspberry Pi CM5 with a carrier board
 (such as WaveShare CM5-IO-BASE-B) and a M.2 SSD to have the fastest boot times.
@@ -102,4 +61,27 @@ sudo reboot
 ```
 sudo systemctl disable --now NetworkManager-wait-online.service
 sudo systemctl mask NetworkManager-wait-online.service
+```
+
+## Build Ui24RBridge
+```
+# Install dependencies
+sudo apt install libasound2-dev
+
+# Install the .NET SDK
+wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+chmod +x ./dotnet-install.sh
+./dotnet-install.sh
+rm ./dotnet-install.sh
+echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
+echo 'export PATH=$PATH:$HOME/.dotnet' >> ~/.bashrc
+source ~/.bashrc
+
+# Clone the repository
+git clone https://github.com/MatthewInch/UI24RBridge.git
+
+# Build
+cd UI24RBridge/UI24RBridgeTest/
+dotnet build -c Release
+
 ```

--- a/Linux.md
+++ b/Linux.md
@@ -1,12 +1,12 @@
-# How to install UI24RBridge to raspberry PI
+# How to install UI24RBridge to Raspberry Pi
 
 - Install arm64 ubuntu linux to raspberry
 - Install .net Core 3.1 runtime from [here]( https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu)
     - manual installation steps (article)[https://sumodh.com/2020/05/05/how-to-install-net-core-x64-sdk-in-raspberry-pi-4/?doing_wp_cron=1618749257.7842419147491455078125]:
         - Download the Arm64 linux binaries from [here](https://dotnet.microsoft.com/download/dotnet/3.1)
-        - sudo mkdir -p $HOME/dotnet  
-          sudo tar zxf dotnet-sdk-3.1.408-linux-arm.tar.gz -C $HOME/dotnet  
-          export DOTNET_ROOT=$HOME/dotnet  
+        - sudo mkdir -p $HOME/dotnet
+          sudo tar zxf dotnet-sdk-3.1.408-linux-arm.tar.gz -C $HOME/dotnet
+          export DOTNET_ROOT=$HOME/dotnet
           export PATH=$PATH:$HOME/dotnet
         - Add the two last row to the profle
           sudo nano .profile
@@ -37,3 +37,69 @@ sudo mkdir -p $HOME/dotnet
 sudo tar zxf dotnet-sdk-3.1.100-linux-arm.tar.gz -C $HOME/dotnet
 export DOTNET_ROOT=$HOME/dotnet
 export PATH=$PATH:$HOME/dotnet
+
+
+# Raspberry PI CM5
+The most efficient approach is to use a Raspberry Pi CM5 with a carrier board
+(such as WaveShare CM5-IO-BASE-B) and a M.2 SSD to have the fastest boot times.
+
+## Hardware
+Below tested hardware configuration
+ - Raspberry Pi Compute Module 5, 16 GB RAM, Wireless
+ - M2 2242 size SSD, 128 GB (SK M2 NVME 2242 128GB)
+ - WaveShare CM5-IO-BASE-B carrier board
+ - Raspberry Pi Compute Module 5 Passive Cooler
+ - (Optional) Compute Module CM4/CM5 Antenna kit
+
+Install the M2 SSD and CM5 module with the provided screws.
+
+To fit the passive cooler, unscrew the fan that comes with the CM5-IO-BASE-B
+carrier board and position it outside the box, routing the cable back inside
+through one of the openings.
+
+The antenna kit is required to use WiFi, as the box will significantly
+attenuate any WiFi signals from reaching the onboard antenna. Note you
+must [update the raspberry pi configuration](https://www.jeffgeerling.com/blog/2022/enable-external-antenna-connector-on-raspberry-pi-compute-module-45/)
+to use the external antenna.
+
+## Flashing Raspberry Pi OS
+1. Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+2. Install or build the latest version of [rpiboot](https://github.com/raspberrypi/usbboot)
+(On Windows, download the installer available in the [releases](https://github.com/raspberrypi/usbboot/releases)
+page)
+3. Plug a USB-C cable to your PC while holding down the `BOOT` button. In
+other carrier boards, instead, place a jumper between `nRPIBOOT` and `GND`
+(J2 pins 1-2 in the official CM5 carrier board) before plugging in the
+USB-C cable.
+4. Run `sudo rpiboot` (On windows, launch `rpi-mass-storage-gadget64.bat`).
+This should mount a writeable USB drive on which we'll write the OS image.
+5. Flash the image using the Raspberry Pi Imager utility. (Recommended to use 64-bit
+Raspberry Pi OS)
+
+Source: https://www.waveshare.com/wiki/Compute_Module_Burn_EMMC
+
+## Boot time Tweaks
+A few optional tweaks to improve boot times.
+
+1. Ensure everything is up to date
+```
+sudo apt update && sudo apt full-upgrade
+```
+
+2. Update bootloader and reboot:
+```
+sudo rpi-eeprom-update -a
+sudo reboot
+```
+
+3. Change the boot order to prefer NVMe:
+    - Open the Raspberry Pi configuration editor (`sudo raspi-config`)
+    - Navigate to `Advanced Options` > `Boot` > `Boot Order`
+    - Highlight `NVMe/USB Boot` and press enter
+    - Follow the prompts
+
+4. Disable network wait:
+```
+sudo systemctl disable --now NetworkManager-wait-online.service
+sudo systemctl mask NetworkManager-wait-online.service
+```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The earlier protocol has not been removed but the new functions only implemented
  - The ***knobs*** set the gain on the input channels or Panorama (change the behavior with Pan/Surround button)
  - Channel ***Select***, ***Solo*** and ***Mute*** buttons work on every channel
  - Channel ***Rec*** button sets either Mtk rec or Phantom 48V (selected in appsettings.json)
+ - Channel strip LCD **second line** shows the channel identifier (e.g. CH01, FX03) and, when viewing AUX/FX sends, appends the send suffix (e.g. CH01-A2, CH05-F1)
  - Buttons ***F1-F8*** switch to AUX1-8 sends
  - Button ***Switch***, ***Option***, ***Control*** and ***Alt*** switch to FX1-4 sends
  - Control Media player with ***<<***, ***>>***, ***Stop***, ***Play*** buttons

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Bridge between the UI24R and a MIDI controllers. Current version can manage one or two controller. If you want to use more you can run more bridge instance.\
 This is a beta project. It tested only on Windows with Behringer X-Touch and X-Touch extender MIDI controllers.
 
-You can download the [latest release here](https://github.com/MatthewInch/UI24RBridge/releases/latest).
-The Linux binary not work in 32bit linux and instabil in 64bit versions
-The MacOS binary wasn't tested
+You can download the [latest release here](https://github.com/MatthewInch/UI24RBridge/releases/latest). Note that the MacOS binary wasn't tested.
+
+For Raspberry Pi or other linux distributions, see instructions [here](Linux.md)
 
 Implemented the Mackie Control protocol (It can work with any DAW controller that can use in MC mode).\
 The earlier protocol has not been removed but the new functions only implemented in MC mode.
@@ -89,7 +89,7 @@ In the settings file (**appsettings.json**):
 	"PrimaryIsExtender": "false",\
 	"SecondaryIsExtender": "true",\
 	"PrimaryChannelStart": "0", //0: 1-8ch, 1: 9-16\
-	"SecondaryChannelStart": "1", //0: 1-8ch, 1: 9-16\	
+	"SecondaryChannelStart": "1", //0: 1-8ch, 1: 9-16\
     "Protocol": "MC",\
     "SyncID": "Abaliget",\
     "DefaultRecButton": "2TrackAndMTK",\

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The earlier protocol has not been removed but the new functions only implemented
  - Channel ***Select***, ***Solo*** and ***Mute*** buttons work on every channel
  - Channel ***Rec*** button sets either Mtk rec or Phantom 48V (selected in appsettings.json)
  - Channel strip LCD **second line** shows the channel identifier (e.g. CH01, FX03) and, when viewing AUX/FX sends, appends the send suffix (e.g. CH01-A2, CH05-F1)
+ - Channel strip **colours** indicate channel type:
+	- **White** — input, line-in, player and main channels
+	- **Yellow** — AUX channels, or any channel when viewing an AUX send layer
+	- **Cyan** — FX channels, or any channel when viewing an FX send layer
+	- **Magenta** — subgroup channels
+	- **Green** — VCA channels
+	- **Black** — empty/unassigned strip
  - Buttons ***F1-F8*** switch to AUX1-8 sends
  - Button ***Switch***, ***Option***, ***Control*** and ***Alt*** switch to FX1-4 sends
  - Control Media player with ***<<***, ***>>***, ***Stop***, ***Play*** buttons

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In the settings file (**appsettings.json**):
 - **PrimaryButtons**: Config file name for buttons behaviour. You can redefine the buttons functionality.
 - **TalkBack**: with scrub button it is emulate the talkback function. The value is a channel number. If the button is pressed that channel is unmuted, if the button is released tha channel is muted. (if the property removed the function is turned off)
 - **RtaOnWhenSelect**: Set RTA on a channel when select that channel on the controller (value can be "true" of "false"
+- **EnableUserBank**: Set to "false" to disable the User bank (Bank U). The ***USER*** button and ***Global View*** button will do nothing. Useful when Bank U is not needed and accidental presses should be avoided. Default is "true"
 
 **Example of the settings file**
 

--- a/UI24RBridgeTest/Program.cs
+++ b/UI24RBridgeTest/Program.cs
@@ -47,6 +47,7 @@ namespace UI24RBridgeTest
             var startBank = configuration["StartBank"];
             var talkBack = configuration["TalkBack"];
             var rtaOnWhenSelect = configuration["RtaOnWhenSelect"] == "true";
+            var enableUserBank = configuration["EnableUserBank"] != "false";
 
 
             var controller = MIDIControllerFactory.GetMidiController(protocol);
@@ -222,6 +223,7 @@ namespace UI24RBridgeTest
                 }
 
                 settings.RtaOnWhenSelect = rtaOnWhenSelect;
+                settings.EnableUserBank = enableUserBank;
 
                 Console.WriteLine("Press 'ESC' to exit.");
                 bool isExit = false;

--- a/UI24RBridgeTest/appsettings.json
+++ b/UI24RBridgeTest/appsettings.json
@@ -30,6 +30,7 @@
   "DefaultRecButton": "2TrackAndMTK", //possible values: "onlyMTK", "only2Track", "2TrackAndMTK"; default is "2TrackAndMTK
   "DefaultChannelRecButton": "rec", //possible values: "phantom", "rec"; default is "rec
   "DebugMessages": "true",
+  "EnableUserBank": "true",
   "AuxButtonBehavior": "Release", //possible values: "Release", "Lock"; Default is "Release"
   "StartBank": "0", //possible values: 0 - Bank I (Degfault), 1 - Bank V (Global View Groups), 2 - Bank U (User defined)
   "TalkBack": "20", //use scrub button. if it is uncommented it unmute the channel (number in value) if button is release the channel will mute

--- a/UI24RController/Enums.cs
+++ b/UI24RController/Enums.cs
@@ -233,4 +233,16 @@ namespace UI24RController
             }
         }
     }
+
+    public enum ChannelStripColour : byte
+    {
+        Black    = 0x00,
+        Red      = 0x01,
+        Green    = 0x02,
+        Yellow   = 0x03,
+        Blue     = 0x04,
+        Magenta  = 0x05,
+        Cyan     = 0x06,
+        White    = 0x07,
+    }
 }

--- a/UI24RController/MIDIController/IMIDIController.cs
+++ b/UI24RController/MIDIController/IMIDIController.cs
@@ -106,8 +106,10 @@ public interface IMIDIController
     void SetLed(ButtonsEnum buttonName, bool turnOn);
 
     public void WriteTextToChannelLCD(int channelNumber, string text, int line);
-    public void WriteTextToChannelLCDFirstLine(int channelNumber, string text);
-    public void WriteTextToChannelLCDSecondLine(int channelNumber, string text);
+    public void WriteDefaultTextToChannelLCDFirstLine(int channelNumber, string text);
+    public void WriteTemporaryTextToChannelLCDFirstLine(int channelNumber, string text, int seconds);
+    public void WriteDefaultTextToChannelLCDSecondLine(int channelNumber, string text);
+    public void WriteTemporaryTextToChannelLCDSecondLine(int channelNumber, string text, int seconds);
     public void WriteTextToLCDSecondLine(string text);
     public void WriteTextToLCDSecondLine(string text, int delay);
 

--- a/UI24RController/MIDIController/IMIDIController.cs
+++ b/UI24RController/MIDIController/IMIDIController.cs
@@ -104,6 +104,7 @@ public interface IMIDIController
     void SetSoloLed(int channelNumber, bool turnOn);
     void SetRecLed(int channelNumber, bool turnOn);
     void SetLed(ButtonsEnum buttonName, bool turnOn);
+    void SetChannelStripColour(int channelNumber, ChannelStripColour colour);
 
     public void WriteTextToChannelLCD(int channelNumber, string text, int line);
     public void WriteDefaultTextToChannelLCDFirstLine(int channelNumber, string text);

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -33,6 +33,12 @@ namespace UI24RController.MIDIController
                 IsTouched = false;
             }
         }
+
+        /// <summary>
+        /// Keep track of last MIDI status byte
+        /// </summary>
+        protected byte? _lastMidiStatus;
+
         /// <summary>
         /// Store every fader setted value of the faders, key is the channel number (z in the message)
         /// </summary>
@@ -156,6 +162,56 @@ namespace UI24RController.MIDIController
             //byte[] sysex = new byte[] { 0xf0, 0, 0, 0x66, 0x14, 0x61, 0xf7 };
             //Send(sysex, 0, sysex.Length, 0);
         }
+
+        protected byte[] NormalizeRunningStatus(byte[] data)
+        {
+            if (data == null || data.Length == 0)
+            {
+                return data;
+            }
+
+            var first = data[0];
+
+            // If the first byte is a status byte, track it, depending on type
+            // See: https://studiocode.dev/kb/MIDI/midi/
+            //   Channel messages can have running status. That is, if the next
+            //   channel status byte is the same as the last, it may be omitted.
+            //   The receiver assumes that the accompanying data is of the same
+            //   status as was last sent. Receipt of any other status byte except
+            //   real-time terminates running status.
+            if ((first & 0x80) != 0)
+            {
+                // Channel voice messages: valid running status
+                if (first >= 0x80 && first <= 0xEF)
+                {
+                    _lastMidiStatus = first;
+                }
+                // System exclusive / system common: cancel running status
+                else if (first >= 0xF0 && first <= 0xF7)
+                {
+                    _lastMidiStatus = null;
+                }
+                // System real-time: leave running status unchanged
+                else if (first >= 0xF8)
+                {
+                    // no change
+                }
+
+                return data;
+            }
+
+            // If the first byte is data, rebuild the message using the last known status.
+            if (_lastMidiStatus is byte status)
+            {
+                var normalized = new byte[data.Length + 1];
+                normalized[0] = status;
+                Buffer.BlockCopy(data, 0, normalized, 1, data.Length);
+                return normalized;
+            }
+
+            return data;
+        }
+
         protected void OnMessageReceived(string message)
         {
             MessageReceived?.Invoke(this, new MessageEventArgs(message));
@@ -425,6 +481,7 @@ namespace UI24RController.MIDIController
 
         public async Task<bool> ConnectInputDevice(string deviceName)
         {
+            _lastMidiStatus = null;
             try
             {
                 _inputDeviceName = deviceName;
@@ -438,9 +495,8 @@ namespace UI24RController.MIDIController
                     _inputDeviceNumber = deviceNumber.Id;
                     _input.MessageReceived += (obj, e) =>
                     {
-                        if (e.Data.Length > 2)
+                        if (e.Data.Length > 0)
                         {
-                            OnMessageReceived($"{e.Data[0].ToString("x2")} - {e.Data[1].ToString("x2")} - {e.Data[2].ToString("x2")}");
                             ProcessMidiMessage(e);
                         }
                     };
@@ -538,7 +594,14 @@ namespace UI24RController.MIDIController
         }
         private void ProcessMidiMessage(MidiReceivedEventArgs e)
         {
-            var message = e.Data;
+            var message = NormalizeRunningStatus(e.Data);
+
+            if (message == null || message.Length < 3)
+            {
+                return;
+            }
+
+            OnMessageReceived($"{message[0]:x2} - {message[1]:x2} - {message[2]:x2}");
 
             if (message[0] == 0x90) //button pressed, released, fader released
             {
@@ -812,7 +875,7 @@ namespace UI24RController.MIDIController
                 }
 
             }
-            else if (message[0] == 0xb0 && (message[1] >= 0x10 && message[1] <= 0x17)) //channel knobb turning
+            else if (message[0] == 0xb0 && message[1] >= 0x10 && message[1] <= 0x17) //channel knobb turning
             {
                 byte channelNumber = (byte)(message[1] - 0x10);
                 if (message[2] >= 0x01 && message[2] <= 0x03)

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -461,22 +461,31 @@ namespace UI24RController.MIDIController
         public void Dispose()
         {
             _isConnected = false;
+
             if (_pingThread != null)
             {
-                //stop the pinging thread
                 _isConnectionErrorOccured = true;
             }
+
+            // On linux, input and output ports might be the same device. The input
+            // port owns the resource and should be the one to dispose it
+
+            bool samePort = _input != null && _output != null
+                    && _input.Details?.Id == _output.Details?.Id;
+
+            if (_output != null && !samePort)
+            {
+                _output.Dispose();
+            }
+
+            _output = null;
+
+
             if (_input != null)
             {
                 _input.Dispose();
                 _input = null;
             }
-            if (_output != null)
-            {
-                _output.Dispose();
-                _output = null;
-            }
-
         }
 
         public async Task<bool> ConnectInputDevice(string deviceName)

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -51,6 +51,9 @@ namespace UI24RController.MIDIController
         protected string _outputDeviceNumber;
         protected string _outputDeviceName;
         protected Guid _lcdTextSyncGuid = Guid.NewGuid();
+        private const int ChannelStripCount = 8;
+        private readonly string[][] _lineDefault = new[] { new string[ChannelStripCount], new string[ChannelStripCount] };
+        private readonly Timer[][] _lineTempTimer = new[] { new Timer[ChannelStripCount], new Timer[ChannelStripCount] };
         protected bool _isConnected = false;
         protected bool _isConnectionErrorOccured = false;
         protected Thread _pingThread;
@@ -978,35 +981,68 @@ namespace UI24RController.MIDIController
                 Send(sysex, 0, sysex.Length, 0);
             }
         }
-        public void WriteTextToChannelLCDFirstLine(int channelNumber, string text)
+        private void WriteDefaultText(int channelNumber, int line, string text)
         {
-            WriteTextToChannelLCD(channelNumber, text, 0);
+            if (channelNumber >= 0 && channelNumber < ChannelStripCount)
+            {
+                _lineTempTimer[line][channelNumber]?.Dispose();
+                _lineTempTimer[line][channelNumber] = null;
+                _lineDefault[line][channelNumber] = text;
+            }
+            WriteTextToChannelLCD(channelNumber, text, line);
         }
-        public void WriteTextToChannelLCDSecondLine(int channelNumber, string text)
+
+        private void WriteTemporaryText(int channelNumber, int line, string text, int seconds)
         {
-            WriteTextToChannelLCD(channelNumber, text, 1);
+            if (channelNumber < 0 || channelNumber >= ChannelStripCount) return;
+            _lineTempTimer[line][channelNumber]?.Dispose();
+            WriteTextToChannelLCD(channelNumber, text, line);
+            _lineTempTimer[line][channelNumber] = new Timer(_ =>
+            {
+                _lineTempTimer[line][channelNumber]?.Dispose();
+                _lineTempTimer[line][channelNumber] = null;
+                WriteTextToChannelLCD(channelNumber, _lineDefault[line][channelNumber] ?? "", line);
+            }, null, seconds * 1000, Timeout.Infinite);
         }
-        public void WriteTextToLCDSecondLine( string text)
+
+        public void WriteDefaultTextToChannelLCDFirstLine(int channelNumber, string text) =>
+            WriteDefaultText(channelNumber, 0, text);
+
+        public void WriteTemporaryTextToChannelLCDFirstLine(int channelNumber, string text, int seconds) =>
+            WriteTemporaryText(channelNumber, 0, text, seconds);
+
+        public void WriteDefaultTextToChannelLCDSecondLine(int channelNumber, string text) =>
+            WriteDefaultText(channelNumber, 1, text);
+
+        public void WriteTemporaryTextToChannelLCDSecondLine(int channelNumber, string text, int seconds) =>
+            WriteTemporaryText(channelNumber, 1, text, seconds);
+
+        public void WriteTextToLCDSecondLine(string text)
         {
-                var message = ASCIIEncoding.ASCII.GetBytes((text + "                                                        ").Substring(0, 50));
-                byte[] sysex = (new byte[] { 0xf0, 0, 0, 0x66, _lcdDisplayNumber, 0x12, 0x38 }).Concat(message).Concat(new byte[] { 0xf7 }).ToArray();
-                Send(sysex, 0, sysex.Length, 0);
+            _lcdTextSyncGuid = Guid.NewGuid();
+            var padded = (text + new string(' ', ChannelStripCount * 7)).Substring(0, ChannelStripCount * 7);
+            var message = ASCIIEncoding.ASCII.GetBytes(padded);
+            byte[] sysex = (new byte[] { 0xf0, 0, 0, 0x66, _lcdDisplayNumber, 0x12, 0x38 }).Concat(message).Concat(new byte[] { 0xf7 }).ToArray();
+            Send(sysex, 0, sysex.Length, 0);
         }
+
         public void WriteTextToLCDSecondLine(string text, int delay)
         {
-            WriteTextToLCDSecondLine(text);
             var guid = Guid.NewGuid();
             _lcdTextSyncGuid = guid;
+            var padded = (text + new string(' ', ChannelStripCount * 7)).Substring(0, ChannelStripCount * 7);
+            var message = ASCIIEncoding.ASCII.GetBytes(padded);
+            byte[] sysex = (new byte[] { 0xf0, 0, 0, 0x66, _lcdDisplayNumber, 0x12, 0x38 }).Concat(message).Concat(new byte[] { 0xf7 }).ToArray();
+            Send(sysex, 0, sysex.Length, 0);
             new Thread(() =>
             {
                 Thread.Sleep(delay * 1000);
-                //if value change the other thread write back the last fader value
                 if (guid == _lcdTextSyncGuid)
                 {
-                    WriteTextToLCDSecondLine("");
+                    for (int i = 0; i < ChannelStripCount; i++)
+                        WriteTextToChannelLCD(i, _lineDefault[1][i] ?? "", 1);
                 }
             }).Start();
-
         }
 
         private byte convertStringToDisplayBytes(string str, int poz = 0)

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -437,23 +437,13 @@ namespace UI24RController.MIDIController
 
         protected void OnConnectionErrorEvent()
         {
-            if (ConnectionErrorEvent != null )
-            {
-                _isConnectionErrorOccured = true;
-                _isConnected = false;
-                ConnectionErrorEvent(this, new EventArgs());
-            }
+            _isConnectionErrorOccured = true;
+            _isConnected = false;
+            ConnectionErrorEvent?.Invoke(this, new EventArgs());
         }
 
-        public void Dispose()
+        private void DisposePorts()
         {
-            _isConnected = false;
-
-            if (_pingThread != null)
-            {
-                _isConnectionErrorOccured = true;
-            }
-
             // On linux, input and output ports might be the same device. The input
             // port owns the resource and should be the one to dispose it
 
@@ -473,6 +463,19 @@ namespace UI24RController.MIDIController
                 _input.Dispose();
                 _input = null;
             }
+        }
+
+
+        public void Dispose()
+        {
+            _isConnected = false;
+
+            if (_pingThread != null)
+            {
+                _isConnectionErrorOccured = true;
+            }
+
+            DisposePorts();
         }
 
         public async Task<bool> ConnectInputDevice(string deviceName)
@@ -546,10 +549,23 @@ namespace UI24RController.MIDIController
                 {
                     while (!_isConnectionErrorOccured)
                     {
-                        Thread.Sleep(5000);
-                        Send(new byte[] { 0xb0, 0x00, 0x00 }, 0, 3, 0);
+                        Thread.Sleep(1000);
+
+                        bool deviceStillPresent = MidiAccessManager.Default.Inputs
+                            .Any(i => i.Name.ToUpper() == _inputDeviceName.ToUpper());
+
+                        if (!deviceStillPresent)
+                        {
+                            OnConnectionErrorEvent();
+                        }
+                        else
+                        {
+                            Send(new byte[] { 0xb0, 0x00, 0x00 }, 0, 3, 0);
+                        }
                     }
                 });
+
+                _pingThread.IsBackground = true;
             }
             if (!_pingThread.IsAlive)
                 _pingThread.Start();
@@ -557,6 +573,7 @@ namespace UI24RController.MIDIController
         }
         public async Task<bool> ReConnectDevice()
         {
+            DisposePorts();
             var inputOk  = await ConnectInputDevice(_inputDeviceName);
             var outputOk = await ConnectOutputDevice(_outputDeviceName);
             return inputOk && outputOk;

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -163,53 +163,40 @@ namespace UI24RController.MIDIController
             //Send(sysex, 0, sysex.Length, 0);
         }
 
-        protected byte[] NormalizeRunningStatus(byte[] data)
+        protected IEnumerable<byte[]> NormalizeAndSplitMidiMessages(byte[] data, int start, int length)
         {
-            if (data == null || data.Length == 0)
-            {
-                return data;
-            }
+            int i = start;
+            int end = start + length;
 
-            var first = data[0];
-
-            // If the first byte is a status byte, track it, depending on type
-            // See: https://studiocode.dev/kb/MIDI/midi/
-            //   Channel messages can have running status. That is, if the next
-            //   channel status byte is the same as the last, it may be omitted.
-            //   The receiver assumes that the accompanying data is of the same
-            //   status as was last sent. Receipt of any other status byte except
-            //   real-time terminates running status.
-            if ((first & 0x80) != 0)
+            while (i < end)
             {
-                // Channel voice messages: valid running status
-                if (first >= 0x80 && first <= 0xEF)
+                byte first = data[i];
+
+                // If the first byte is a status byte, track it, depending on type
+                // See: https://studiocode.dev/kb/MIDI/midi/
+                //   Channel messages can have running status. That is, if the next
+                //   channel status byte is the same as the last, it may be omitted.
+                //   The receiver assumes that the accompanying data is of the same
+                //   status as was last sent. Receipt of any other status byte except
+                //   real-time terminates running status.
+
+                if ((first & 0x80) != 0)
                 {
+                    // Status byte present: full 3-byte message
                     _lastMidiStatus = first;
+                    if (i + 3 > end) yield break;
+                    yield return new byte[] { data[i], data[i + 1], data[i + 2] };
+                    i += 3;
                 }
-                // System exclusive / system common: cancel running status
-                else if (first >= 0xF0 && first <= 0xF7)
+                else
                 {
-                    _lastMidiStatus = null;
+                    // Running status: 2 data bytes, prepend last known status
+                    if (_lastMidiStatus == null) { i++; continue; } // no known status, skip
+                    if (i + 2 > end) yield break;
+                    yield return new byte[] { _lastMidiStatus.Value, data[i], data[i + 1] };
+                    i += 2;
                 }
-                // System real-time: leave running status unchanged
-                else if (first >= 0xF8)
-                {
-                    // no change
-                }
-
-                return data;
             }
-
-            // If the first byte is data, rebuild the message using the last known status.
-            if (_lastMidiStatus is byte status)
-            {
-                var normalized = new byte[data.Length + 1];
-                normalized[0] = status;
-                Buffer.BlockCopy(data, 0, normalized, 1, data.Length);
-                return normalized;
-            }
-
-            return data;
         }
 
         protected void OnMessageReceived(string message)
@@ -603,301 +590,294 @@ namespace UI24RController.MIDIController
         }
         private void ProcessMidiMessage(MidiReceivedEventArgs e)
         {
-            var message = NormalizeRunningStatus(e.Data);
-
-            if (message == null || message.Length < 3)
+            foreach (var message in NormalizeAndSplitMidiMessages(e.Data, e.Start, e.Length))
             {
-                return;
-            }
-
-            OnMessageReceived($"{message[0]:x2} - {message[1]:x2} - {message[2]:x2}");
-
-            if (message[0] == 0x90) //button pressed, released, fader released
-            {
-                if (message.MIDIEqual(0x90, 0x00, 0x00, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //release fader (0x90 [0x68-0x70] 0x00)
+                if (message[0] == 0x90) //button pressed, released, fader released
                 {
-                    byte channelNumber = (byte)(message[1] - 0x68);
-                    if (faderValues.ContainsKey(channelNumber))
+                    if (message.MIDIEqual(0x90, 0x00, 0x00, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //release fader (0x90 [0x68-0x70] 0x00)
                     {
-                        faderValues[channelNumber].IsTouched = false;
-                        SetFader(channelNumber, faderValues[channelNumber].Value);
-                    }
-                }
-                if (message.MIDIEqual(0x90, 0x00, 0x7f, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //touch fader (0x90 [0x68-0x70] 0x00)
-                {
-                    byte channelNumber = (byte)(message[1] - 0x68);
-                    if (faderValues.ContainsKey(channelNumber))
-                    {
-                        faderValues[channelNumber].IsTouched = true;
-                    }
-                }
-
-                else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Mute] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Mute] + 7) && message[2] == 0x7f) //channel mute button
-                {
-                    byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Mute]);
-                    OnChannelMuteEvent(channelNumber);
-                }
-                else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Solo] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Solo] + 7) && message[2] == 0x7f) //channel solo button
-                {
-                    byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Solo]);
-                    OnChannelSoloEvent(channelNumber);
-                }
-                else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Rec] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Rec] + 7) && message[2] == 0x7f) //channel rec button
-                {
-                    byte channelNumber = (byte)(message[1]- _buttonsID[ButtonsEnum.Ch1Rec]);
-                    OnChannelRecEvent(channelNumber);
-                }
-                else if  (message[1] >= _buttonsID[ButtonsEnum.Ch1Select] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Select] + 7) && message[2] == 0x7f) //channel select button
-                {
-                    byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Select]);
-                    OnChannelSelectEvent(channelNumber);
-                }
-                else if (message.MIDIEqual(0x90, 0x32, 0x7f)) //main select button
-                {
-                    OnChannelSelectEvent(8);
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Track], 0x7f))
-                {
-                    OnTrackEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Pan], 0x7f))
-                {
-                    OnPanEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Eq], 0x7f))
-                {
-                    OnEqEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Send], 0x7f))
-                {
-                    OnSendEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlugIn], 0x7f))
-                {
-                    OnPlugInEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Instr], 0x7f))
-                {
-                    OnInstrEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Display], 0x7f))
-                {
-                    OnDisplayBtnEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Smtpe], 0x7f))
-                {
-                    OnSmtpeBeatsBtnEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.GlobalView], 0x7f))
-                {
-                    OnGlobalViewEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.MidiTracks], 0x7f))
-                {
-                    OnMidiTracksEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Inputs], 0x7f))
-                {
-                    OnInputsEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioTracks], 0x7f))
-                {
-                    OnAudioTracksEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioInst], 0x7f))
-                {
-                    OnAudioInstEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AuxBtn], 0x7f))
-                {
-                    OnAuxBtnEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.BusesBtn], 0x7f))
-                {
-                    OnBusesBtnEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Outputs], 0x7f))
-                {
-                    OnOutputsEvent();
-                }
-                else if ((message[0] == 0x90) && message[1] == _buttonsID[ButtonsEnum.User])
-                {
-                    OnUserEvent(0, message[2] == 0x7f);
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Save], 0x7f))
-                {
-                    OnSaveEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Undo], 0x7f))
-                {
-                    OnUndoEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cancel], 0x7f))
-                {
-                    OnCancelEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Enter], 0x7f))
-                {
-                    OnEnterEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Marker], 0x7f))
-                {
-                    OnMarkerEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Nudge], 0x7f))
-                {
-                    OnNudgeEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cycle], 0x7f))
-                {
-                    OnCycleEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Drop], 0x7f))
-                {
-                    OnDropEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Replace], 0x7f))
-                {
-                    OnReplaceEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Click], 0x7f))
-                {
-                    OnClickEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Solo], 0x7f))
-                {
-                    OnSoloEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayPrev], 0x7f))
-                {
-                    OnPrevEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayNext], 0x7f))
-                {
-                    OnNextEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Stop], 0x7f))
-                {
-                    OnStopEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Play], 0x7f))
-                {
-                    OnPlayEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Rec], 0x7f))
-                {
-                    OnRecEvent();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankUp], 0x7f))
-                {
-                    OnBankUp();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankDown], 0x7f))
-                {
-                    OnBankDown();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelUp], 0x7f))
-                {
-                    OnLayerUp();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelDown], 0x7f))
-                {
-                    OnLayerDown();
-                }
-
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Up], 0x7f))
-                {
-                    OnUpEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Down], 0x7f))
-                {
-                    OnDownEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Left], 0x7f))
-                {
-                    OnLeftEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Right], 0x7f))
-                {
-                    OnRightEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Center], 0x7f))
-                {
-                    OnCenterEvent();
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x00))
-                {
-                    OnScrubEvent(true);
-                }
-                else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x7f))
-                {
-                    OnScrubEvent(false);
-                }
-
-                else if (message[0]== 0x90 && _buttonsID.GetAuxButton(message[1]).isAux) //F1-F8 press
-                {
-                    var auxNum = _buttonsID.GetAuxButton(message[1]).auxNum;
-                    OnAuxButtonEvent(auxNum, message[2] == 0x7f);
-                }
-                else if ((message[0] == 0x90) && _buttonsID.GetFxButton(message[1]).isFX)
-                {
-                    var fxNum = _buttonsID.GetFxButton(message[1]).fxNum;
-                    OnFxButtonEvent(fxNum, message[2] == 0x7f);
-                }
-                else if ((message[0] == 0x90) && _buttonsID.GetMuteGroupsButton(message[1]).isMuteGroupButton)
-                {
-                    var muteNum = _buttonsID.GetMuteGroupsButton(message[1]).muteGroupNum;
-                    OnMuteGroupButtonEvent(muteNum, message[2] == 0x7f);
-                }
-
-            }
-            else if (message[0] >= 0xe0 && (message[0] <= 0xe8)) //move fader
-            {
-                byte channelNumber = (byte)(message[0] - 0xe0);
-                //int data2 = (int)Math.Round(faderValue * 1023); //10 bit
-                int upper = message[2] << 7; //upper 7 bit
-                int lower = message[1]; // lower 7 bit
-
-                var faderValue = (upper + lower) / 16383.0;
-
-                faderValues[channelNumber].Value = faderValue;
-                OnFaderEvent(channelNumber, faderValue);
-                if (!faderValues[channelNumber].IsTouched)
-                {
-                    new Thread(() =>
-                    {
-                        Thread.Sleep(100);
-                        //if value change the other thread write back the last fader value
-                        if (faderValue == faderValues[channelNumber].Value)
+                        byte channelNumber = (byte)(message[1] - 0x68);
+                        if (faderValues.ContainsKey(channelNumber))
                         {
-                            SetFader(channelNumber, faderValue);
+                            faderValues[channelNumber].IsTouched = false;
+                            SetFader(channelNumber, faderValues[channelNumber].Value);
                         }
-                    }).Start();
-                }
+                    }
+                    else if (message.MIDIEqual(0x90, 0x00, 0x7f, 0xff, 0x00, 0xff) && (message[1] >= 0x68) && (message[1] <= 0x70)) //touch fader (0x90 [0x68-0x70] 0x00)
+                    {
+                        byte channelNumber = (byte)(message[1] - 0x68);
+                        if (faderValues.ContainsKey(channelNumber))
+                        {
+                            faderValues[channelNumber].IsTouched = true;
+                        }
+                    }
+                    else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Mute] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Mute] + 7) && message[2] == 0x7f) //channel mute button
+                    {
+                        byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Mute]);
+                        OnChannelMuteEvent(channelNumber);
+                    }
+                    else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Solo] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Solo] + 7) && message[2] == 0x7f) //channel solo button
+                    {
+                        byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Solo]);
+                        OnChannelSoloEvent(channelNumber);
+                    }
+                    else if (message[1] >= _buttonsID[ButtonsEnum.Ch1Rec] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Rec] + 7) && message[2] == 0x7f) //channel rec button
+                    {
+                        byte channelNumber = (byte)(message[1]- _buttonsID[ButtonsEnum.Ch1Rec]);
+                        OnChannelRecEvent(channelNumber);
+                    }
+                    else if  (message[1] >= _buttonsID[ButtonsEnum.Ch1Select] && message[1] <= (_buttonsID[ButtonsEnum.Ch1Select] + 7) && message[2] == 0x7f) //channel select button
+                    {
+                        byte channelNumber = (byte)(message[1] - _buttonsID[ButtonsEnum.Ch1Select]);
+                        OnChannelSelectEvent(channelNumber);
+                    }
+                    else if (message.MIDIEqual(0x90, 0x32, 0x7f)) //main select button
+                    {
+                        OnChannelSelectEvent(8);
+                    }
 
-            }
-            else if (message[0] == 0xb0 && message[1] >= 0x10 && message[1] <= 0x17) //channel knobb turning
-            {
-                byte channelNumber = (byte)(message[1] - 0x10);
-                if (message[2] >= 0x01 && message[2] <= 0x03)
-                    OnKnobEvent(channelNumber, message[2]);
-                if (message[2] >= 0x41 && message[2] <= 0x43)
-                    OnKnobEvent(channelNumber, -1 * (message[2] & 0x03));
-            }
-            else if (message[0] == 0xb0 && message[1] == 0x3c ) //jog wheel turning
-            {
-                if (message[2] >= 0x01 && message[2] <= 0x03)
-                    OnWheelEvent(0, message[2]);
-                if (message[2] >= 0x41 && message[2] <= 0x43)
-                    OnWheelEvent(0, -1 * (message[2] & 0x03));
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Track], 0x7f))
+                    {
+                        OnTrackEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Pan], 0x7f))
+                    {
+                        OnPanEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Eq], 0x7f))
+                    {
+                        OnEqEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Send], 0x7f))
+                    {
+                        OnSendEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlugIn], 0x7f))
+                    {
+                        OnPlugInEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Instr], 0x7f))
+                    {
+                        OnInstrEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Display], 0x7f))
+                    {
+                        OnDisplayBtnEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Smtpe], 0x7f))
+                    {
+                        OnSmtpeBeatsBtnEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.GlobalView], 0x7f))
+                    {
+                        OnGlobalViewEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.MidiTracks], 0x7f))
+                    {
+                        OnMidiTracksEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Inputs], 0x7f))
+                    {
+                        OnInputsEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioTracks], 0x7f))
+                    {
+                        OnAudioTracksEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AudioInst], 0x7f))
+                    {
+                        OnAudioInstEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.AuxBtn], 0x7f))
+                    {
+                        OnAuxBtnEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.BusesBtn], 0x7f))
+                    {
+                        OnBusesBtnEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Outputs], 0x7f))
+                    {
+                        OnOutputsEvent();
+                    }
+                    else if ((message[0] == 0x90) && message[1] == _buttonsID[ButtonsEnum.User])
+                    {
+                        OnUserEvent(0, message[2] == 0x7f);
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Save], 0x7f))
+                    {
+                        OnSaveEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Undo], 0x7f))
+                    {
+                        OnUndoEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cancel], 0x7f))
+                    {
+                        OnCancelEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Enter], 0x7f))
+                    {
+                        OnEnterEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Marker], 0x7f))
+                    {
+                        OnMarkerEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Nudge], 0x7f))
+                    {
+                        OnNudgeEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Cycle], 0x7f))
+                    {
+                        OnCycleEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Drop], 0x7f))
+                    {
+                        OnDropEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Replace], 0x7f))
+                    {
+                        OnReplaceEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Click], 0x7f))
+                    {
+                        OnClickEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Solo], 0x7f))
+                    {
+                        OnSoloEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayPrev], 0x7f))
+                    {
+                        OnPrevEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.PlayNext], 0x7f))
+                    {
+                        OnNextEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Stop], 0x7f))
+                    {
+                        OnStopEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Play], 0x7f))
+                    {
+                        OnPlayEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Rec], 0x7f))
+                    {
+                        OnRecEvent();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankUp], 0x7f))
+                    {
+                        OnBankUp();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.FaderBankDown], 0x7f))
+                    {
+                        OnBankDown();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelUp], 0x7f))
+                    {
+                        OnLayerUp();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.ChannelDown], 0x7f))
+                    {
+                        OnLayerDown();
+                    }
+
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Up], 0x7f))
+                    {
+                        OnUpEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Down], 0x7f))
+                    {
+                        OnDownEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Left], 0x7f))
+                    {
+                        OnLeftEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Right], 0x7f))
+                    {
+                        OnRightEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Center], 0x7f))
+                    {
+                        OnCenterEvent();
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x00))
+                    {
+                        OnScrubEvent(true);
+                    }
+                    else if (message.MIDIEqual(0x90, _buttonsID[ButtonsEnum.Scrub], 0x7f))
+                    {
+                        OnScrubEvent(false);
+                    }
+
+                    else if (message[0]== 0x90 && _buttonsID.GetAuxButton(message[1]).isAux) //F1-F8 press
+                    {
+                        var auxNum = _buttonsID.GetAuxButton(message[1]).auxNum;
+                        OnAuxButtonEvent(auxNum, message[2] == 0x7f);
+                    }
+                    else if ((message[0] == 0x90) && _buttonsID.GetFxButton(message[1]).isFX)
+                    {
+                        var fxNum = _buttonsID.GetFxButton(message[1]).fxNum;
+                        OnFxButtonEvent(fxNum, message[2] == 0x7f);
+                    }
+                    else if ((message[0] == 0x90) && _buttonsID.GetMuteGroupsButton(message[1]).isMuteGroupButton)
+                    {
+                        var muteNum = _buttonsID.GetMuteGroupsButton(message[1]).muteGroupNum;
+                        OnMuteGroupButtonEvent(muteNum, message[2] == 0x7f);
+                    }
+
+                }
+                else if (message[0] >= 0xe0 && (message[0] <= 0xe8)) //move fader
+                {
+                    byte channelNumber = (byte)(message[0] - 0xe0);
+                    //int data2 = (int)Math.Round(faderValue * 1023); //10 bit
+                    int upper = message[2] << 7; //upper 7 bit
+                    int lower = message[1]; // lower 7 bit
+
+                    var faderValue = (upper + lower) / 16383.0;
+
+                    faderValues[channelNumber].Value = faderValue;
+                    OnFaderEvent(channelNumber, faderValue);
+                    if (!faderValues[channelNumber].IsTouched)
+                    {
+                        new Thread(() =>
+                        {
+                            Thread.Sleep(100);
+                            //if value change the other thread write back the last fader value
+                            if (faderValue == faderValues[channelNumber].Value)
+                            {
+                                SetFader(channelNumber, faderValue);
+                            }
+                        }).Start();
+                    }
+
+                }
+                else if (message[0] == 0xb0 && message[1] >= 0x10 && message[1] <= 0x17) //channel knobb turning
+                {
+                    byte channelNumber = (byte)(message[1] - 0x10);
+                    if (message[2] >= 0x01 && message[2] <= 0x03)
+                        OnKnobEvent(channelNumber, message[2]);
+                    if (message[2] >= 0x41 && message[2] <= 0x43)
+                        OnKnobEvent(channelNumber, -1 * (message[2] & 0x03));
+                }
+                else if (message[0] == 0xb0 && message[1] == 0x3c ) //jog wheel turning
+                {
+                    if (message[2] >= 0x01 && message[2] <= 0x03)
+                        OnWheelEvent(0, message[2]);
+                    if (message[2] >= 0x41 && message[2] <= 0x43)
+                        OnWheelEvent(0, -1 * (message[2] & 0x03));
+                }
             }
         }
 

--- a/UI24RController/MIDIController/MC.cs
+++ b/UI24RController/MIDIController/MC.cs
@@ -54,6 +54,7 @@ namespace UI24RController.MIDIController
         private const int ChannelStripCount = 8;
         private readonly string[][] _lineDefault = new[] { new string[ChannelStripCount], new string[ChannelStripCount] };
         private readonly Timer[][] _lineTempTimer = new[] { new Timer[ChannelStripCount], new Timer[ChannelStripCount] };
+        private readonly ChannelStripColour[] _stripColours = Enumerable.Repeat(ChannelStripColour.White, ChannelStripCount).ToArray();
         protected bool _isConnected = false;
         protected bool _isConnectionErrorOccured = false;
         protected Thread _pingThread;
@@ -967,6 +968,17 @@ namespace UI24RController.MIDIController
         public void SetLed(ButtonsEnum buttonName, bool turnOn)
         {
             Send(new byte[] { 0x90, _buttonsID[buttonName], (byte)(turnOn ? 0x7f : 0x00) }, 0, 3, 0);
+        }
+
+        public void SetChannelStripColour(int channelNumber, ChannelStripColour colour)
+        {
+            if (channelNumber < 0 || channelNumber >= ChannelStripCount) return;
+            _stripColours[channelNumber] = colour;
+            byte[] sysex = new byte[] { 0xf0, 0x00, 0x00, 0x66, _lcdDisplayNumber, 0x72,
+                (byte)_stripColours[0], (byte)_stripColours[1], (byte)_stripColours[2], (byte)_stripColours[3],
+                (byte)_stripColours[4], (byte)_stripColours[5], (byte)_stripColours[6], (byte)_stripColours[7],
+                0xf7 };
+            Send(sysex, 0, sysex.Length, 0);
         }
 
         public void WriteTextToChannelLCD(int channelNumber, string text, int line = 0)

--- a/UI24RController/Settings/BridgeSettings.cs
+++ b/UI24RController/Settings/BridgeSettings.cs
@@ -44,6 +44,7 @@ namespace UI24RController
 
         public int TalkBack { get; set; }
         public bool RtaOnWhenSelect { get; set; }
+        public bool EnableUserBank { get; set; } = true;
 
         public BridgeSettings(string address, Action<string, bool> messageWriter) 
             : this(address, messageWriter, "SYNC_ID", RecButtonBehaviorEnum.TwoTrackAndMTK, ChannelRecButtonBehaviorEnum.Rec)

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -41,7 +41,7 @@ namespace UI24RController
         /// Represent the UI24R mixer state
         /// TODO: need to move every global variable that store any mixer specific state to the Mixer class (viewGroups, selectedChannel etc.)
         /// </summary>
-        protected Mixer _mixer = new Mixer();
+        protected Mixer _mixer;
 
         //0-23: Input channels
         //24-25: Linie In L/R
@@ -66,6 +66,7 @@ namespace UI24RController
         {
             this._settings = settings;
             this._controllers = controllers;
+            _mixer = new Mixer(settings.EnableUserBank);
             SendMessage("Start initialization...", false);
             InitializeChannels();
             InitializeViewGroupsFromConfig();
@@ -845,6 +846,7 @@ namespace UI24RController
 
         public void _midiController_UserLayerEdit(IMIDIController controller, FunctionEventArgs e)
         {
+            if (!_settings.EnableUserBank) return;
             _mixer.UserLayerEdit = e.IsPress;
             //if (_secondaryBridge != null) _secondaryBridge.UserLayerEdit = e.IsPress;
 
@@ -917,6 +919,7 @@ namespace UI24RController
         }
         public void _midiController_SaveEvent(IMIDIController controller, EventArgs e)
         {
+            if (!_settings.EnableUserBank) return;
             string jsonString;
             jsonString = JsonSerializer.Serialize(_mixer.getUserLayerToArray(), MyClassTypeResolver<int[][]>.GetSerializerOptions());
             File.WriteAllText(CONFIGFILE_VIEW_GROUP, jsonString);

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -598,11 +598,13 @@ namespace UI24RController
             {
                 if (e.IsPress)
                 {
+                    if (_selectedLayout.IsAux() || _selectedLayout.IsFx())
+                        controller.SetLed(_selectedLayout.ToButtonsEnum(), false);
                     _selectedLayout = e.FunctionButton.ToAux();
                     controller.SetLed(_selectedLayout.ToButtonsEnum(), true);
                     controller.WriteTextToBarsDisplay("AX" + (_selectedLayout.AuxToInt() + 1).ToString());
                 }
-                else
+                else if (_selectedLayout == e.FunctionButton.ToAux())
                 {
                     controller.SetLed(_selectedLayout.ToButtonsEnum(), false);
                     _selectedLayout = SelectedLayoutEnum.Channels;
@@ -640,11 +642,13 @@ namespace UI24RController
             {
                 if (e.IsPress)
                 {
+                    if (_selectedLayout.IsAux() || _selectedLayout.IsFx())
+                        controller.SetLed(_selectedLayout.ToButtonsEnum(), false);
                     _selectedLayout = e.FunctionButton.ToFx();
                     controller.SetLed(_selectedLayout.ToButtonsEnum(), true);
                     controller.WriteTextToBarsDisplay("FX" + (_selectedLayout.FxToInt() + 1).ToString());
                 }
-                else
+                else if (_selectedLayout == e.FunctionButton.ToFx())
                 {
                     controller.SetLed(_selectedLayout.ToButtonsEnum(), false);
                     _selectedLayout = SelectedLayoutEnum.Channels;

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -22,6 +22,7 @@ namespace UI24RController
 
         const string CONFIGFILE_VIEW_GROUP = "ViewGroups.json";
 
+        private readonly HashSet<IMIDIController> _reconnectingControllers = new HashSet<IMIDIController>();
         protected BridgeSettings _settings;
         protected List<IMIDIController> _controllers;
         protected WebsocketClient _client;
@@ -134,29 +135,38 @@ namespace UI24RController
         private void _midiController_ConnectionErrorEvent(IMIDIController controller, EventArgs e)
         {
             SendMessage("Midi controller connection error.", false);
-            SendMessage("Try to reconnect....", false);
-            if (!_isReconnecting)
+
+            lock (_reconnectingControllers)
             {
-                new Thread(async () =>
+                if (_reconnectingControllers.Contains(controller))
                 {
-                    _isReconnecting = true;
-                    while (_isReconnecting && !await controller.ReConnectDevice())
-                    {
-                        Thread.Sleep(100);
-                    }
-
-                    SetControllerToCurrentLayerAndSend();
-                    SetStateLedsOnController();
-
-                    SendMessage("Midi controller reconnected.", false);
-                    _isReconnecting = false;
-                }).Start();
+                    SendMessage("Reconnection already in progress for this controller.");
+                    return;
+                }
+                _reconnectingControllers.Add(controller);
             }
-            else
+
+            SendMessage("Try to reconnect....", false);
+
+            new Thread(async () =>
             {
-                SendMessage("Reconnection state is true...");
-            }
-        }
+                while (!await controller.ReConnectDevice())
+                {
+                    Thread.Sleep(200);
+                }
+
+                controller.InitializeController();
+                SetControllerToCurrentLayerAndSend();
+                SetStateLedsOnController();
+
+                SendMessage("Midi controller reconnected.", false);
+
+                lock (_reconnectingControllers)
+                {
+                    _reconnectingControllers.Remove(controller);
+                }
+            }).Start();
+    }
         private void WebsocketReconnectionHappened(ReconnectionInfo info)
         {
             _controllers.ForEach(c=> c.WriteTextToLCDSecondLine("UI24R is reconnected",5));

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -201,12 +201,23 @@ namespace UI24RController
     }
         private void WebsocketReconnectionHappened(ReconnectionInfo info)
         {
-            _controllers.ForEach(c=> c.WriteTextToLCDSecondLine("UI24R is reconnected",5));
+            if (info.Type != ReconnectionType.Initial)
+                _controllers.ForEach(c => c.WriteTextToLCDSecondLine("UI24R is reconnected", 5));
+
+            Task.Run(async () =>
+            {
+                await Task.Delay(500); // Wait for Ui24R to send us all data
+                SetControllerToCurrentLayerAndSend();
+                SetStateLedsOnController();
+                SendMessage("Mixer state synced to controller.", false);
+            });
         }
+
         private void WebsocketDisconnectionHappened(DisconnectionInfo info)
         {
             _controllers.ForEach(c => c.WriteTextToLCDSecondLine("UI24R disconnected. Try to reconnect"));
         }
+
         private void InitializeViewGroupsFromConfig()
         {
             if (File.Exists(CONFIGFILE_VIEW_GROUP))

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using System.Net.WebSockets;
 using System.Threading;
 using UI24RController.UI24RChannels;
@@ -114,14 +115,28 @@ namespace UI24RController
             //    _midiController_ConnectionErrorEvent(this, null);
             //}
             _mixer.setBank(_settings.StartBank);
-            SendMessage("Start websocket connection...", false);
-            _client = new WebsocketClient(new Uri(_settings.Address));
-            _client.MessageReceived.Subscribe(msg => UI24RMessageReceived(msg));
-            _client.DisconnectionHappened.Subscribe(info => WebsocketDisconnectionHappened(info));
-            _client.ReconnectionHappened.Subscribe(info => WebsocketReconnectionHappened(info));
-            _client.ErrorReconnectTimeout = new TimeSpan(0,0,10);
-            SendMessage("Connecting to UI24R....", false);
-            _client.Start();
+
+            Task.Run(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        _client = _createWebsocketClient();
+                        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                        await _client.Start().WaitAsync(cts.Token);
+                        SendMessage($"UI24R connected.", false);
+                        break;
+                    }
+                    catch
+                    {
+                        SendMessage($"UI24R not reachable, retrying in 5 seconds...", false);
+                        try { _client.Dispose(); } catch { }
+                        await Task.Delay(5000);
+                    }
+                }
+            });
+
             controllers.ForEach(c=> c.WriteTextToAssignmentDisplay(_mixer.getCurrentLayerString()));
             //if (settings.ControllerStartChannel != null && settings.ControllerStartChannel == "1")
             //{
@@ -130,6 +145,23 @@ namespace UI24RController
             SetStateLedsOnController();
         }
 
+
+        private WebsocketClient _createWebsocketClient()
+        {
+            var client = new WebsocketClient(new Uri(_settings.Address), () =>
+            {
+                var socket = new ClientWebSocket();
+                socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(1);
+                return socket;
+            });
+            client.ReconnectTimeout = TimeSpan.FromSeconds(5);
+            client.ErrorReconnectTimeout = TimeSpan.FromSeconds(5);
+            client.IsReconnectionEnabled = true;
+            client.MessageReceived.Subscribe(msg => UI24RMessageReceived(msg));
+            client.DisconnectionHappened.Subscribe(info => WebsocketDisconnectionHappened(info));
+            client.ReconnectionHappened.Subscribe(info => WebsocketReconnectionHappened(info));
+            return client;
+        }
 
 
         private void _midiController_ConnectionErrorEvent(IMIDIController controller, EventArgs e)

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -975,10 +975,24 @@ namespace UI24RController
             }
         }
 
+        private ChannelStripColour GetChannelStripColour(int channelNumber)
+        {
+            if (_selectedLayout.IsAux()) return ChannelStripColour.Yellow;
+            if (_selectedLayout.IsFx())  return ChannelStripColour.Cyan;
+            var ch = _mixerChannels[channelNumber];
+            if (ch is SubgroupChannel) return ChannelStripColour.Magenta;
+            if (ch is AuxChannel)      return ChannelStripColour.Yellow;
+            if (ch is FXChannel)       return ChannelStripColour.Cyan;
+            if (ch is VCAChannel)      return ChannelStripColour.Green;
+            return ChannelStripColour.White;
+        }
+
         private void SetControllerChannelToCurrentLayerAndSend(IMIDIController controller, int channelNumber, int controllerChannelNumber)
         {
             if (channelNumber > -1)
             {
+                controller.SetChannelStripColour(controllerChannelNumber, GetChannelStripColour(channelNumber));
+
                 if (_selectedLayout == SelectedLayoutEnum.Channels)
                 {
                     controller.SetFader(controllerChannelNumber, _mixerChannels[channelNumber].ChannelFaderValue);
@@ -1030,6 +1044,7 @@ namespace UI24RController
 
                 controller.WriteDefaultTextToChannelLCDFirstLine(controllerChannelNumber, "");
                 controller.WriteDefaultTextToChannelLCDSecondLine(controllerChannelNumber, "");
+                controller.SetChannelStripColour(controllerChannelNumber, ChannelStripColour.Black);
                 controller.SetMuteLed(controllerChannelNumber, false);
                 controller.SetSoloLed(controllerChannelNumber, false);
                 controller.SetRecLed(controllerChannelNumber, false);

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -540,50 +540,55 @@ namespace UI24RController
             //}
         }
 
+        private void _syncStereoLinkedChannel(int ch, double faderValue)
+        {
+            if (!(_mixerChannels[ch] is IStereoLinkable stereoChannel) || stereoChannel.LinkedWith == -1)
+                return;
+
+            var otherCh = stereoChannel.LinkedWith == 0 ? ch + 1 : ch - 1;
+
+            if (_selectedLayout == SelectedLayoutEnum.Channels || _mixerChannels[ch] is MainChannel)
+            {
+                _mixerChannels[otherCh].ChannelFaderValue = faderValue;
+                _client.Send(_mixerChannels[otherCh].MixFaderMessage());
+            }
+            else
+            {
+                _mixerChannels[otherCh].AuxSendValues[_selectedLayout] = faderValue;
+                if (_selectedLayout.IsAux())
+                    _client.Send(_mixerChannels[otherCh].SetAuxValueMessage(_selectedLayout));
+                else if (_selectedLayout.IsFx())
+                    _client.Send(_mixerChannels[otherCh].SetFxValueMessage(_selectedLayout));
+            }
+
+            var otherChOnLayers = GetControllerChannel(otherCh);
+            otherChOnLayers.ForEach(otherChOnLayer =>
+            {
+                if (otherChOnLayer.isOnLayer)
+                    otherChOnLayer.controller.SetFader(otherChOnLayer.controllerChannelNumber, faderValue);
+            });
+        }
+
         private void _midiController_FaderEvent(IMIDIController controller, MIDIController.FaderEventArgs e)
         {
             var ch = _mixer.getChannelNumberInCurrentLayer(e.ChannelNumber, controller.ChannelOffset);
             if (ch > -1)
             {
-                //if (_pressedFunctionButton == -1) or it is a master fader
-                if ((_selectedLayout == SelectedLayoutEnum.Channels) || (_mixerChannels[ch] is MainChannel))
+                if (_selectedLayout == SelectedLayoutEnum.Channels || _mixerChannels[ch] is MainChannel)
                 {
                     _mixerChannels[ch].ChannelFaderValue = e.FaderValue;
                     _client.Send(_mixerChannels[ch].MixFaderMessage());
-                    //if the channel is linked we have to set the other channel to the same value
-                    if (_mixerChannels[ch] is IStereoLinkable)
-                    {
-                        var stereoChannel = _mixerChannels[ch] as IStereoLinkable;
-                        if (stereoChannel.LinkedWith != -1)
-                        {
-                            var otherCh = stereoChannel.LinkedWith == 0 ? ch + 1 : ch - 1;
-                            _mixerChannels[otherCh].ChannelFaderValue = e.FaderValue;
-                            _client.Send(_mixerChannels[otherCh].MixFaderMessage());
-                            //If the other chanel is on the current layout we have to set too
-                            var otherChOnLayers = GetControllerChannel(otherCh);
-                            otherChOnLayers.ForEach(otherChOnLayer =>
-                            {
-                                if (otherChOnLayer.isOnLayer)
-                                {
-                                    otherChOnLayer.controller.SetFader(otherChOnLayer.controllerChannelNumber, e.FaderValue);
-                                }
-                            });
-                        }
-                    }
                 }
                 else
                 {
-                    //_mixerChannels[ch].AuxSendValues[_pressedFunctionButton] = e.FaderValue;
                     _mixerChannels[ch].AuxSendValues[_selectedLayout] = e.FaderValue;
                     if (_selectedLayout.IsAux())
-                    {
                         _client.Send(_mixerChannels[ch].SetAuxValueMessage(_selectedLayout));
-                    }
                     else if (_selectedLayout.IsFx())
-                    {
                         _client.Send(_mixerChannels[ch].SetFxValueMessage(_selectedLayout));
-                    }
                 }
+
+                _syncStereoLinkedChannel(ch, e.FaderValue);
             }
         }
 

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -458,14 +458,13 @@ namespace UI24RController
                             var currentGainChannel = _mixerChannels[ch] as IInputable;
                             if (currentGainChannel.SrcType == SrcTypeEnum.Hw)
                             {
-                                currentGainChannel.Gain = currentGainChannel.Gain + (1.0d / 100.0d) * e.KnobDirection;
-                                if (currentGainChannel.Gain > 1)
-                                    currentGainChannel.Gain = 1;
-                                if (currentGainChannel.Gain < 0)
-                                    currentGainChannel.Gain = 0;
+                                int currentDb = (int)Math.Round(currentGainChannel.Gain * 63 - 6);
+                                int newDb = Math.Clamp(currentDb + e.KnobDirection, -6, 57);
+                                currentGainChannel.Gain = (newDb + 6) / 63.0d;
 
                                 _client.Send(currentGainChannel.GainMessage());
                                 controller.SetKnobLed(e.ChannelNumber, currentGainChannel.Gain);
+                                controller.WriteTemporaryTextToChannelLCDFirstLine(e.ChannelNumber, FormatGain(currentGainChannel.Gain), 2);
                                 //if multiple channels are set to same HW input
                                 foreach (var singleChannel in _mixerChannels)
                                 {
@@ -487,14 +486,13 @@ namespace UI24RController
                         break;
                     case KnobsFunctionEnum.Pan:
                         var currentChannel = _mixerChannels[ch];
-                        currentChannel.Panorama = currentChannel.Panorama + (1.0d / 100.0d) * e.KnobDirection;
-                        if (currentChannel.Panorama > 1)
-                            currentChannel.Panorama = 1;
-                        if (currentChannel.Panorama < 0)
-                            currentChannel.Panorama = 0;
+                        int currentPan = (int)Math.Round((currentChannel.Panorama - 0.5) * 200);
+                        int newPan = Math.Clamp(currentPan + e.KnobDirection, -100, 100);
+                        currentChannel.Panorama = newPan / 200.0d + 0.5d;
 
                         _client.Send(currentChannel.PanoramaMessage());
                         controller.SetKnobLed(e.ChannelNumber, currentChannel.Panorama);
+                        controller.WriteTemporaryTextToChannelLCDFirstLine(e.ChannelNumber, FormatPan(currentChannel.Panorama), 2);
                         break;
                 }
             }
@@ -980,6 +978,19 @@ namespace UI24RController
                 _client.Send(msg.Text);
                 _client.Send("3:::ALIVE");
             }
+        }
+
+        private static string FormatGain(double gain)
+        {
+            int db = (int)Math.Round(gain * 63 - 6);
+            return db >= 0 ? $"+{db}dB" : $"{db}dB";
+        }
+
+        private static string FormatPan(double pan)
+        {
+            int value = (int)Math.Round((pan - 0.5) * 200);
+            if (value == 0) return "CENTER";
+            return value < 0 ? $"{-value}L" : $"{value}R";
         }
 
         private ChannelStripColour GetChannelStripColour(int channelNumber)

--- a/UI24RController/UI24RBridge.cs
+++ b/UI24RController/UI24RBridge.cs
@@ -889,7 +889,7 @@ namespace UI24RController
             {
                 int controllerPos = Array.IndexOf(_mixer.getCurrentLayer(controller.ChannelOffset), SelectedChannel);
                 _mixer.setNewUserChannelInCurrentBank(controllerPos);
-                controller.WriteTextToChannelLCDSecondLine(controllerPos, "");
+                controller.WriteDefaultTextToChannelLCDSecondLine(controllerPos, "");
                 SetControllerChannelToCurrentLayerAndSend(controller, _mixer.UserLayerEditNewChannel, controllerPos);
 
             }
@@ -905,7 +905,7 @@ namespace UI24RController
                     //find next channel not used on this layer
                     int controllerPos = Array.IndexOf(_mixer.getCurrentLayer(otherController.ChannelOffset), SelectedChannel);
                     _mixer.findNextAvailableChannelForUserLayer(controllerPos, e.WheelDirection, otherController.ChannelOffset);
-                    controller.WriteTextToChannelLCDSecondLine(controllerPos, _mixerChannels[_mixer.UserLayerEditNewChannel].Name);
+                    controller.WriteDefaultTextToChannelLCDSecondLine(controllerPos, _mixerChannels[_mixer.UserLayerEditNewChannel].Name);
                 }
 
             }
@@ -999,7 +999,10 @@ namespace UI24RController
 
                 SetControllerChannelKnobb(controller, channelNumber, controllerChannelNumber);
 
-                controller.WriteTextToChannelLCDFirstLine(controllerChannelNumber, _mixerChannels[channelNumber].Name);
+                controller.WriteDefaultTextToChannelLCDFirstLine(controllerChannelNumber, _mixerChannels[channelNumber].Name);
+                controller.WriteDefaultTextToChannelLCDSecondLine(controllerChannelNumber,
+                    _mixerChannels[channelNumber].GetDisplayName(_selectedLayout));
+
                 controller.SetMuteLed(controllerChannelNumber, _mixerChannels[channelNumber].IsMute);
                 controller.SetSoloLed(controllerChannelNumber, _mixerChannels[channelNumber].IsSolo);
 
@@ -1025,7 +1028,8 @@ namespace UI24RController
                 controller.SetSelectLed(controllerChannelNumber, false);
                 controller.SetKnobLed(controllerChannelNumber, 0);
 
-                controller.WriteTextToChannelLCDFirstLine(controllerChannelNumber, "");
+                controller.WriteDefaultTextToChannelLCDFirstLine(controllerChannelNumber, "");
+                controller.WriteDefaultTextToChannelLCDSecondLine(controllerChannelNumber, "");
                 controller.SetMuteLed(controllerChannelNumber, false);
                 controller.SetSoloLed(controllerChannelNumber, false);
                 controller.SetRecLed(controllerChannelNumber, false);
@@ -1159,7 +1163,7 @@ namespace UI24RController
 
                                 if (ui24Message.IsValid && chOnLayer.controllerChannelNumber < 8)
                                 {
-                                    chOnLayer.controller.WriteTextToChannelLCDFirstLine(chOnLayer.controllerChannelNumber, _mixerChannels[ui24Message.ChannelNumber].Name);
+                                    chOnLayer.controller.WriteDefaultTextToChannelLCDFirstLine(chOnLayer.controllerChannelNumber, _mixerChannels[ui24Message.ChannelNumber].Name);
                                 }
                             }
                             break;

--- a/UI24RController/UI24RChannels/AuxChannel.cs
+++ b/UI24RController/UI24RChannels/AuxChannel.cs
@@ -15,6 +15,8 @@ namespace UI24RController.UI24RChannels
             Eq.ChannelType = channelTypeID;
         }
 
+        public override string ShortName => $"AUX{ChannelNumber + 1:D1}";
+
         protected override string GetDefaultName()
         {
             return $"AUX {(this.ChannelNumber + 1):D2}"; ;

--- a/UI24RController/UI24RChannels/ChannelBase.cs
+++ b/UI24RController/UI24RChannels/ChannelBase.cs
@@ -10,7 +10,7 @@ namespace UI24RController.UI24RChannels
         /// <summary>
         /// Between 0 and 1.0
         /// </summary>
-        /// 
+        ///
         public ChannelBase(int channelNumber)
         {
             ChannelFaderValue = 0;
@@ -59,7 +59,10 @@ namespace UI24RController.UI24RChannels
                 {
                     _name = GetDefaultName();
                 }
-                else _name = value;
+                else
+                {
+                    _name = value;
+                }
             }
         }
 
@@ -67,6 +70,18 @@ namespace UI24RController.UI24RChannels
         public bool IsSelected { get; set; }
         public int VCA { get; set; }
         protected bool _muteBtn;
+        public virtual string ShortName => GetDefaultName().Length > 4 ? GetDefaultName().Substring(0, 4) : GetDefaultName();
+        public string GetDisplayName(SelectedLayoutEnum layout)
+        {
+            if (layout == SelectedLayoutEnum.Channels)
+                return ShortName;
+            if (layout.IsAux())
+                return $"{ShortName}-A{layout.AuxToInt() + 1}";
+            if (layout.IsFx())
+                return $"{ShortName}-F{layout.FxToInt() + 1}";
+            return ShortName;
+        }
+
         public bool IsMute
         {
             get
@@ -157,7 +172,6 @@ namespace UI24RController.UI24RChannels
 
         public virtual string TurnOnRTAMessage()
         {
-            
             return $"3:::SETS^var.rta^{this.channelTypeID}.{this.ChannelNumber}";
         }
 

--- a/UI24RController/UI24RChannels/FXChannel.cs
+++ b/UI24RController/UI24RChannels/FXChannel.cs
@@ -14,6 +14,8 @@ namespace UI24RController.UI24RChannels
             _muteGroupMaskDefault = 1 << Mixer._muteAllBit | 1 << Mixer._muteAllFxBit;
         }
 
+        public override string ShortName => $"FX{(this.ChannelNumber + 1):D2}";
+
         protected override string GetDefaultName()
         {
             return $"FX {(this.ChannelNumber + 1):D2}";

--- a/UI24RController/UI24RChannels/InputChannel.cs
+++ b/UI24RController/UI24RChannels/InputChannel.cs
@@ -26,6 +26,9 @@ namespace UI24RController.UI24RChannels
             Gain = 0;
             IsPhantom = false;
         }
+
+        public override string ShortName => $"CH{(this.ChannelNumber + 1):D2}";
+
         protected override string GetDefaultName()
         {
             return $"CH {(this.ChannelNumber + 1):D2}";

--- a/UI24RController/UI24RChannels/LineInChannel.cs
+++ b/UI24RController/UI24RChannels/LineInChannel.cs
@@ -28,6 +28,8 @@ namespace UI24RController.UI24RChannels
             IsPhantom = false;
         }
 
+        public override string ShortName => ChannelNumber == 0 ? "LinL" : "LinR";
+
         protected override string GetDefaultName()
         {
             return this.ChannelNumber == 0 ? "L-IN L" : "L-IN R";

--- a/UI24RController/UI24RChannels/PlayerChannel.cs
+++ b/UI24RController/UI24RChannels/PlayerChannel.cs
@@ -10,7 +10,9 @@ namespace UI24RController.UI24RChannels
         public override int ChannelNumberInMixer => this.ChannelNumber + 26;
 
         public int LinkedWith { get ; set ; }
-       
+
+        public override string ShortName => ChannelNumber == 0 ? "PlyL" : "PlyR";
+
         public PlayerChannel(int channelNumber): base(channelNumber)
         {
             LinkedWith = -1; //-1: not linked, 0 left, 1 right

--- a/UI24RController/UI24RChannels/SubgroupChannel.cs
+++ b/UI24RController/UI24RChannels/SubgroupChannel.cs
@@ -12,6 +12,8 @@ namespace UI24RController.UI24RChannels
             Eq.ChannelType = channelTypeID;
         }
         public override int ChannelNumberInMixer => this.ChannelNumber + 32;
+
+        public override string ShortName => $"SUB{(this.ChannelNumber + 1):D1}";
         protected override string GetDefaultName()
         {
             return $"SUB {(this.ChannelNumber + 1):D2}";

--- a/UI24RController/UI24RChannels/VCAChannel.cs
+++ b/UI24RController/UI24RChannels/VCAChannel.cs
@@ -12,6 +12,8 @@ namespace UI24RController.UI24RChannels
             Eq.ChannelType = channelTypeID;
         }
         public override int ChannelNumberInMixer => this.ChannelNumber + 48;
+        public override string ShortName => $"VCA{(this.ChannelNumber + 1):D1}";
+
         protected override string GetDefaultName()
         {
             return $"VCA {(this.ChannelNumber + 1):D2}";

--- a/UI24RController/UI24RChannels/mixer.cs
+++ b/UI24RController/UI24RChannels/mixer.cs
@@ -22,13 +22,18 @@ namespace UI24RController.UI24RChannels
         /// </summary>
         public bool IsChannelOffset { get; set; }
 
-        public Mixer()
+        private bool _hasUserBank;
+        private int[] _availableBanks;
+
+        public Mixer(bool hasUserBank = true)
         {
             _numLayersPerBank = 6;
             _numBanks = 3;
             _selectedLayer = 0;
             _selectedBank = 0;
             _numFaders = 9;
+            _hasUserBank = hasUserBank;
+            _availableBanks = hasUserBank ? new[] { 0, 1, 2 } : new[] { 0, 2 };
 
             initLayers();
             initMuteGroups();
@@ -65,14 +70,17 @@ namespace UI24RController.UI24RChannels
                 _banks[0][5][j+2] = 48 + j;
 
             //initialize User layers
-            _banks.Add(1, new List<int[]>());
-            for (int i = 0; i < _numLayersPerBank; ++i)
+            if (_hasUserBank)
             {
-                int[] channelLayer = new int[9];
-                for (int j = 0; j < _numFaders - 1; ++j)
-                    channelLayer[j] = j + i * (_numFaders - 1);
-                channelLayer[_numFaders - 1] = 54;
-                _banks[1].Add(channelLayer);
+                _banks.Add(1, new List<int[]>());
+                for (int i = 0; i < _numLayersPerBank; ++i)
+                {
+                    int[] channelLayer = new int[9];
+                    for (int j = 0; j < _numFaders - 1; ++j)
+                        channelLayer[j] = j + i * (_numFaders - 1);
+                    channelLayer[_numFaders - 1] = 54;
+                    _banks[1].Add(channelLayer);
+                }
             }
 
 
@@ -92,6 +100,7 @@ namespace UI24RController.UI24RChannels
         }
         public void setUserLayerFromArray(int[][] input)
         {
+            if (!_hasUserBank) return;
             for (int i = 0; i < input.Length && i < _numLayersPerBank; ++i)
                 if (input[i].Length >= _numFaders - 1)
                     for (int j = 0; j < _numFaders - 1; ++j)
@@ -99,6 +108,7 @@ namespace UI24RController.UI24RChannels
         }
         public int[][] getUserLayerToArray()
         {
+            if (!_hasUserBank) return Array.Empty<int[]>();
             int[][] output = new int[_numLayersPerBank][];
             for (int i = 0; i < _numLayersPerBank; ++i)
             {
@@ -166,16 +176,19 @@ namespace UI24RController.UI24RChannels
 
         public void setBankUp()
         {
-            _selectedBank = (_selectedBank + 1) % _numBanks;
+            int idx = (Array.IndexOf(_availableBanks, _selectedBank) + 1) % _availableBanks.Length;
+            _selectedBank = _availableBanks[idx];
             _selectedLayer = 0;
         }
         public void setBankDown()
         {
-            _selectedBank = (_selectedBank + _numBanks - 1) % _numBanks;
+            int idx = (Array.IndexOf(_availableBanks, _selectedBank) + _availableBanks.Length - 1) % _availableBanks.Length;
+            _selectedBank = _availableBanks[idx];
             _selectedLayer = 0;
         }
         public bool goToUserBank()
         {
+            if (!_hasUserBank) return false;
             bool updated = false;
             if (_selectedBank != 1)
             {


### PR DESCRIPTION
This pull request should be merged after #17 

It adds several useful improvements and fixes - most notably channel colours and use of second line
- Synchronise stereo channels also for AUX and FX Sends
- Add channel descriptions on second line (e.g. CH01, CH02, FX01, FX02) - with suffix when the fader controls a send (e.g. CH01-A1, CH02-F1, etc)
- Add colour support to channel strips (show type of channel with the colour) - requires firmware >1.22 (tested in firmware 1.25)
- Fix stale AUX/FX LED when pressing more than one send button at once
- Add option to disable user banks (Bank U)
- Display Pan/Gain values for 2 seconds on first channel strip line + increment in single value steps
